### PR TITLE
fix: Add MCP configuration schema endpoint to HTTP transport

### DIFF
--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -299,6 +299,23 @@ export async function startHttpServer(config: ServerConfig): Promise<void> {
           };
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ configSchema }, null, 2));
+        } else if (
+          (url === "/.well-known/mcp/server-card.json" ||
+            url === "/.well-known/mcp/mcp/server-card.json") &&
+          req.method === "GET"
+        ) {
+          // Return MCP Server Card for discovery
+          const serverCard = {
+            name: config.name,
+            version: config.version,
+            description: config.description,
+            capabilities: {
+              tools: true,
+              prompts: true,
+            },
+          };
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(serverCard, null, 2));
         } else {
           res.writeHead(404);
           res.end("Not found");


### PR DESCRIPTION
Introduced a new GET endpoint at /.well-known/mcp-config that returns the MCP configuration schema. This enhancement allows clients like Smithery to retrieve necessary configuration details, improving compatibility with the MCP protocol.