### PR TITLE
fix(ci): use GitHub App token for release-please to trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- release-please PRs (#104, #105) don't trigger CI because `GITHUB_TOKEN` events can't trigger other workflows (GitHub anti-recursion rule)
- Switch to a GitHub App token via `actions/create-github-app-token@v2` so release-please PRs trigger the `validate` job
- App tokens are short-lived (1hr) and org-owned — no personal account dependency

## Setup

- `RELEASE_APP_ID` repo variable — GitHub App ID
- `RELEASE_APP_PRIVATE_KEY` repo secret — GitHub App private key (.pem)

## Test plan

- [ ] Merge → release-please re-runs → Release PRs trigger CI validate job