### PR TITLE
fix(ci): add .prettierignore to packages for changelogs

### DIFF
--- a/packages/dgrep/.prettierignore
+++ b/packages/dgrep/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/packages/mcp/.prettierignore
+++ b/packages/mcp/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
Each package runs prettier from its own directory, so the root .prettierignore doesn't apply. Adds CHANGELOG.md exclusion to packages/mcp and packages/dgrep.