### PR TITLE
chore(ci): release-please stamps server.json and gemini-extension.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
 
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF#refs/*/}"
-          VERSION="${VERSION#docfork-v}"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
@@ -46,16 +40,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Stamp version in server.json
-        run: |
-          cd packages/mcp
-          echo $(jq --arg v "${{ env.VERSION }}" '.version = $v | .packages[0].version = $v' server.json) > server.json
-
-      - name: Stamp version in gemini-extension.json
-        run: |
-          cd packages/mcp
-          echo $(jq --arg v "${{ env.VERSION }}" '.version = $v' gemini-extension.json) > gemini-extension.json
 
       - name: Build
         run: pnpm build
@@ -99,21 +83,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set version from tag
-        run: |
-          VERSION="${GITHUB_REF#refs/*/}"
-          VERSION="${VERSION#docfork-v}"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-
-      - name: Update server.json version
-        run: |
-          cd packages/mcp
-          echo $(jq --arg v "${{ env.VERSION }}" '.version = $v | .packages[0].version = $v' server.json) > server.json
 
       - name: Validate server.json
         run: |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,24 @@
   "separate-pull-requests": true,
   "packages": {
     "packages/mcp": {
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        },
+        {
+          "type": "json",
+          "path": "gemini-extension.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "packages/dgrep": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- Add `extra-files` with jsonpath to release-please config so it bumps version in `server.json` (both `$.version` and `$.packages[0].version`) and `gemini-extension.json` in the Release PR itself
- Remove redundant jq version-stamping steps from release.yml — release-please handles this now
- Repo stays in sync: all version files are updated in the Release PR, not at publish time

## Files with MCP version (all now managed by release-please)

| File | Field(s) |
|---|---|
| `packages/mcp/package.json` | `.version` (native node release type) |
| `packages/mcp/server.json` | `.version`, `.packages[0].version` (extra-files jsonpath) |
| `packages/mcp/gemini-extension.json` | `.version` (extra-files jsonpath) |