### PR TITLE
fix(ci): add gemini-extension.json to prettierignore

### DIFF
--- a/packages/mcp/.prettierignore
+++ b/packages/mcp/.prettierignore
@@ -1,1 +1,2 @@
 CHANGELOG.md
+gemini-extension.json


### PR DESCRIPTION
## Summary

- Add `gemini-extension.json` to `packages/mcp/.prettierignore`
- release-please updates this file via `extra-files` config without running Prettier, causing `format:check` failures on release PRs (e.g. #112)

## Test plan

- [ ] Verify PR #112 checks pass after this merges