### PR TITLE
fix(ci): remove npm global upgrade from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,6 @@ jobs:
           cache: "pnpm"
           token: ""
 
-      - name: Ensure npm supports trusted publishing
-        run: |
-          npm i -g npm@^11.5.1
-          npm -v
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -134,11 +129,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
           token: ""
-
-      - name: Ensure npm supports trusted publishing
-        run: |
-          npm i -g npm@^11.5.1
-          npm -v
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Remove `npm i -g npm@^11.5.1` step from both MCP and dgrep publish jobs
- Node 22's bundled npm (10.x) already supports OIDC trusted publishing
- The upgrade step fails with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` on Node 22.22.2, blocking all releases

## Test plan

- [ ] Merge, then re-run the failed `docfork-v2.2.0` and `dgrep-v0.1.1` release workflows