### PR TITLE
fix(ci): restore empty NODE_AUTH_TOKEN for npm OIDC publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,16 @@ jobs:
 
       - name: Publish to npm (stable)
         if: ${{ !github.event.release.prerelease }}
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/mcp
           npm publish --access public --provenance
 
       - name: Publish to npm (pre-release)
         if: ${{ github.event.release.prerelease }}
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/mcp
           npm publish --access public --provenance --tag=beta
@@ -132,12 +136,16 @@ jobs:
 
       - name: Publish to npm (stable)
         if: ${{ !github.event.release.prerelease }}
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/dgrep
           npm publish --access public --provenance
 
       - name: Publish to npm (pre-release)
         if: ${{ github.event.release.prerelease }}
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/dgrep
           npm publish --access public --provenance --tag=beta


### PR DESCRIPTION
## Summary

- Add `NODE_AUTH_TOKEN: ""` env to publish steps (step-level, not job-level)
- `setup-node` with `registry-url` writes `.npmrc` expecting this var — without it, npm fails with E404 before OIDC can negotiate
- This is the same pattern that successfully published v2.1.0

## Test plan

- [ ] Merge, delete + recreate releases, verify both publish to npm