### PR TITLE
fix(ci): use npx npm@latest for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 # This workflow publishes packages to npm when a GitHub release is published.
 # release-please creates GitHub Releases automatically from conventional commits.
 # Tag patterns: docfork-vX.Y.Z (MCP server), dgrep-vX.Y.Z (CLI)
+#
+# Auth: OIDC trusted publishing (no npm tokens). Requires npm >= 11.5.1,
+# id-token: write, and trusted publisher configured on npmjs.com for each package.
+# Do NOT set NODE_AUTH_TOKEN or registry-url — both interfere with OIDC.
 
 name: Release
 
@@ -14,7 +18,7 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'docfork-v')
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Required for OIDC trusted publishing
+      id-token: write
       contents: write
     steps:
       - name: Checkout Repo
@@ -27,7 +31,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 
       - name: Install dependencies
@@ -54,19 +57,15 @@ jobs:
 
       - name: Publish to npm (stable)
         if: ${{ !github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/mcp
-          npm publish --access public --provenance
+          npx npm@latest publish --access public --provenance
 
       - name: Publish to npm (pre-release)
         if: ${{ github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/mcp
-          npm publish --access public --provenance --tag=beta
+          npx npm@latest publish --access public --provenance --tag=beta
 
   # -- MCP Registry ----------------------------------------
   publish_registry:
@@ -125,7 +124,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 
       - name: Install dependencies
@@ -136,16 +134,12 @@ jobs:
 
       - name: Publish to npm (stable)
         if: ${{ !github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/dgrep
-          npm publish --access public --provenance
+          npx npm@latest publish --access public --provenance
 
       - name: Publish to npm (pre-release)
         if: ${{ github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ""
         run: |
           cd packages/dgrep
-          npm publish --access public --provenance --tag=beta
+          npx npm@latest publish --access public --provenance --tag=beta


### PR DESCRIPTION
## Summary

Fixes npm publish failures (`ENEEDAUTH`, `E404`) by properly configuring OIDC trusted publishing:

- **Remove `NODE_AUTH_TOKEN`** — even empty string blocks OIDC on npm 11.x+ / Node 22.14+
- **Remove `registry-url`** from setup-node — the generated `.npmrc` conflicts with OIDC
- **Use `npx npm@latest publish`** — Node 22 ships npm 10.x which lacks OIDC support; global install fails with MODULE_NOT_FOUND on 22.22.2, but `npx` works

References: [npm trusted publishing docs](https://docs.npmjs.com/trusted-publishers/), [setup-node #1445](https://github.com/actions/setup-node/issues/1445)

## Test plan

- [ ] Merge, delete + recreate both releases, verify npm publish succeeds
- [ ] Verify provenance badge appears on npmjs.com package pages