### PR TITLE
fix(dgrep): add repository.url for npm provenance

### DIFF
--- a/packages/dgrep/package.json
+++ b/packages/dgrep/package.json
@@ -37,5 +37,10 @@
     "vitest": "^3",
     "yargs": "^18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/docfork/docfork",
+    "directory": "packages/dgrep"
+  },
   "homepage": "https://github.com/docfork/docfork#readme"
 }


### PR DESCRIPTION
## Summary

- Add `repository` field to `packages/dgrep/package.json`
- npm OIDC provenance verification requires `repository.url` to match the GitHub repo — without it, publish fails with E422

Note: `docfork` (MCP) published successfully — only `dgrep` was missing this field.

## Test plan

- [ ] Merge, delete + recreate dgrep release, verify npm publish succeeds