### PR TITLE
fix(dgrep): use absolute URL for demo.gif in README

### DIFF
--- a/packages/dgrep/README.md
+++ b/packages/dgrep/README.md
@@ -2,7 +2,7 @@
 
 The CLI for [Docfork](https://docfork.com), the documentation index for AI coding agents. Search versioned library docs from the terminal.
 
-dgrep demo
+<img src="https://raw.githubusercontent.com/docfork/docfork/main/demo.gif" alt="dgrep demo" />
 
 ```bash
 npx dgrep


### PR DESCRIPTION
## Summary

- Replace placeholder text with absolute `raw.githubusercontent.com` URL for demo.gif
- Single gif lives in repo root, works on both GitHub and npmjs.com