### PR TITLE
feat(dgrep): send X-Docfork-Client header on every API request

### DIFF
--- a/packages/dgrep/src/bin.ts
+++ b/packages/dgrep/src/bin.ts
@@ -4,6 +4,7 @@ import { hideBin } from "yargs/helpers";
 import pc from "picocolors";
 import { DgrepError } from "./lib/errors.js";
 import { loadAccent } from "./lib/theme.js";
+import { VERSION } from "./lib/version.js";
 
 async function main() {
   await loadAccent();
@@ -21,7 +22,7 @@ async function main() {
         const pc = (await import("picocolors")).default;
         console.log("");
         console.log(
-          `  ${pc.bold("dgrep")} ${pc.dim("v0.1.0")} — ${config.libraries.length} libraries tracked`
+          `  ${pc.bold("dgrep")} ${pc.dim(`v${VERSION}`)} — ${config.libraries.length} libraries tracked`
         );
         console.log("");
         console.log(`  ${pc.dim("dgrep search <query>")}    Search documentation`);

--- a/packages/dgrep/src/lib/api-client.ts
+++ b/packages/dgrep/src/lib/api-client.ts
@@ -1,7 +1,7 @@
 import { AuthError, NetworkError, NotFoundError, RateLimitError } from "./errors.js";
+import { VERSION } from "./version.js";
 
 export const API_URL = "https://api.docfork.com/v1";
-const VERSION = "0.1.0";
 
 export interface DgrepAuthConfig {
   apiKey?: string;

--- a/packages/dgrep/src/lib/api-client.ts
+++ b/packages/dgrep/src/lib/api-client.ts
@@ -24,6 +24,7 @@ export function parseErrorMessage(text: string, status: number, statusText: stri
 function headers(auth?: DgrepAuthConfig): Record<string, string> {
   const h: Record<string, string> = {
     "User-Agent": `dgrep/${VERSION}`,
+    "X-Docfork-Client": `dgrep/${VERSION}`,
     "Content-Type": "application/json",
     Accept: "application/json",
   };

--- a/packages/dgrep/src/lib/version.ts
+++ b/packages/dgrep/src/lib/version.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// obuild may inline this module into dist/bin.mjs (__dirname = dist/) or emit
+// it into dist/_chunks/ (__dirname = dist/_chunks/). Try both.
+function readPackageVersion(): string {
+  for (const candidate of [
+    join(__dirname, "..", "package.json"),
+    join(__dirname, "..", "..", "package.json"),
+  ]) {
+    try {
+      const pkg = JSON.parse(readFileSync(candidate, "utf-8")) as { version?: string };
+      if (typeof pkg.version === "string") return pkg.version;
+    } catch {
+      // try next candidate
+    }
+  }
+  return "0.0.0";
+}
+
+export const VERSION: string = readPackageVersion();

--- a/packages/dgrep/test/lib/api-client.test.ts
+++ b/packages/dgrep/test/lib/api-client.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { searchDocs, readUrl, searchCatalog } from "../../src/lib/api-client.js";
+import {
+  searchDocs,
+  readUrl,
+  searchCatalog,
+  batchSearchDocs,
+  resolvePackages,
+  provisionKey,
+} from "../../src/lib/api-client.js";
 import { AuthError, RateLimitError, NotFoundError, NetworkError } from "../../src/lib/errors.js";
+import { VERSION } from "../../src/lib/version.js";
 import { server } from "../setup.js";
 import { http, HttpResponse } from "msw";
 
@@ -57,5 +65,67 @@ describe("searchCatalog", () => {
     const result = await searchCatalog("react");
     expect(result.libraries).toHaveLength(1);
     expect(result.libraries[0].identifier).toBe("facebook/react");
+  });
+});
+
+describe("X-Docfork-Client header", () => {
+  const expected = `dgrep/${VERSION}`;
+
+  async function captureClientHeader(
+    path: string,
+    method: "get" | "post",
+    trigger: () => Promise<unknown>,
+  ): Promise<string | null> {
+    let header: string | null = null;
+    server.use(
+      http[method](`${API_URL}${path}`, ({ request }) => {
+        header = request.headers.get("x-docfork-client");
+        return HttpResponse.json({});
+      }),
+    );
+    await trigger().catch(() => {
+      // handler returns {} — some callers may throw on shape, ignore for header check
+    });
+    return header;
+  }
+
+  it("sends the header on GET /search", async () => {
+    const header = await captureClientHeader("/search", "get", () =>
+      searchDocs("hooks", "react"),
+    );
+    expect(header).toBe(expected);
+  });
+
+  it("sends the header on POST /search", async () => {
+    const header = await captureClientHeader("/search", "post", () =>
+      batchSearchDocs("hooks", ["react@latest"]),
+    );
+    expect(header).toBe(expected);
+  });
+
+  it("sends the header on GET /read", async () => {
+    const header = await captureClientHeader("/read", "get", () =>
+      readUrl("https://react.dev/reference/react/useState"),
+    );
+    expect(header).toBe(expected);
+  });
+
+  it("sends the header on GET /libraries/search", async () => {
+    const header = await captureClientHeader("/libraries/search", "get", () =>
+      searchCatalog("react"),
+    );
+    expect(header).toBe(expected);
+  });
+
+  it("sends the header on POST /libraries/resolve", async () => {
+    const header = await captureClientHeader("/libraries/resolve", "post", () =>
+      resolvePackages(["react"]),
+    );
+    expect(header).toBe(expected);
+  });
+
+  it("sends the header on POST /keys/provision", async () => {
+    const header = await captureClientHeader("/keys/provision", "post", () => provisionKey());
+    expect(header).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary

Adds `X-Docfork-Client: dgrep/<version>` to every request the dgrep API client sends. Standard request metadata (same category as User-Agent), no opt-out.

Also fixes a pre-existing drift: the source had `VERSION = "0.1.0"` hardcoded while `package.json` was `0.1.2`. VERSION now reads from `package.json` at runtime, so User-Agent and X-Docfork-Client both always match the installed CLI version.

## Context

Part of DOC-221. The backend uses this header to attribute API requests by client surface (CLI vs MCP vs dashboard vs future SDK) in analytics. Ships independently of the rest of the telemetry work so the header starts producing server-side data immediately.

## What changes

- `src/lib/version.ts` (new) — runtime read of `package.json`, handles both obuild output layouts (`dist/bin.mjs` and `dist/_chunks/*.mjs`)
- `src/lib/api-client.ts` — imports VERSION from the new module, adds `X-Docfork-Client` alongside User-Agent in the central `headers()` helper
- `src/bin.ts` — the status-line "dgrep v0.1.0" label now reads the real version
- `test/lib/api-client.test.ts` — asserts the header is present on all 6 API call paths (GET/POST /search, /read, /libraries/search, /libraries/resolve, /keys/provision)

## Test plan

- [x] `pnpm test` — all pass, including 6 new X-Docfork-Client header tests
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:check` — clean
- [x] `pnpm build` — succeeds; `node dist/bin.mjs --version` prints `0.1.2` (was `0.1.0` before)
- [x] Grep confirms `X-Docfork-Client: dgrep/\${VERSION}` present in `dist/_chunks/api-client.mjs`