### PR TITLE
feat(dgrep): add fire-and-forget telemetry transport

### DIFF
--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -1,6 +1,5 @@
 const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
 
-// Widely-set CI variables. Mirrors vercel-labs/add-skill.
 export function isCI(): boolean {
   return !!(
     process.env.CI ||
@@ -14,10 +13,10 @@ export function isCI(): boolean {
   );
 }
 
-// `DO_NOT_TRACK` is the consoledonottrack.com convention: any truthy value
-// opts the user out. `DGREP_TELEMETRY=0` is a dgrep-specific override so the
-// user can turn telemetry off without affecting other CLIs that honor
-// `DO_NOT_TRACK`. Config-based opt-out is layered on top by callers.
+// Two env vars. `DO_NOT_TRACK` opts the user out with any truthy value;
+// `DGREP_TELEMETRY=0` is a dgrep-specific override for users who want to
+// disable dgrep without affecting other tools on their machine.
+// Config-based opt-out is layered on top by callers.
 function envOptOut(): boolean {
   if (process.env.DO_NOT_TRACK && process.env.DO_NOT_TRACK !== "0") return true;
   if (process.env.DGREP_TELEMETRY === "0") return true;

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -1,0 +1,45 @@
+const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
+
+// Widely-set CI variables. Mirrors vercel-labs/add-skill.
+export function isCI(): boolean {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.TRAVIS ||
+    process.env.BUILDKITE ||
+    process.env.JENKINS_URL ||
+    process.env.TEAMCITY_VERSION
+  );
+}
+
+// `DO_NOT_TRACK` is the consoledonottrack.com convention: any truthy value
+// opts the user out. `DGREP_TELEMETRY=0` is a dgrep-specific override so the
+// user can turn telemetry off without affecting other CLIs that honor
+// `DO_NOT_TRACK`. Config-based opt-out is layered on top by callers.
+function envOptOut(): boolean {
+  if (process.env.DO_NOT_TRACK && process.env.DO_NOT_TRACK !== "0") return true;
+  if (process.env.DGREP_TELEMETRY === "0") return true;
+  return false;
+}
+
+export function track(
+  event: string,
+  distinctId: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
+  if (envOptOut()) return Promise.resolve();
+  try {
+    return fetch(TELEMETRY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event, distinct_id: distinctId, properties }),
+    }).then(
+      () => undefined,
+      () => undefined,
+    );
+  } catch {
+    return Promise.resolve();
+  }
+}

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -27,7 +27,7 @@ function envOptOut(): boolean {
 export function track(
   event: string,
   distinctId: string,
-  properties: Record<string, unknown>,
+  properties: Record<string, unknown>
 ): Promise<void> {
   if (envOptOut()) return Promise.resolve();
   try {
@@ -37,7 +37,7 @@ export function track(
       body: JSON.stringify({ event, distinct_id: distinctId, properties }),
     }).then(
       () => undefined,
-      () => undefined,
+      () => undefined
     );
   } catch {
     return Promise.resolve();

--- a/packages/dgrep/test/lib/telemetry/transport.test.ts
+++ b/packages/dgrep/test/lib/telemetry/transport.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { track, isCI } from "../../../src/lib/telemetry/transport.js";
+import { server } from "../../setup.js";
+
+const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
+
+const CI_ENV_VARS = [
+  "CI",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "TRAVIS",
+  "BUILDKITE",
+  "JENKINS_URL",
+  "TEAMCITY_VERSION",
+];
+
+describe("track", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ["DO_NOT_TRACK", "DGREP_TELEMETRY", ...CI_ENV_VARS]) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("POSTs to /v1/telemetry with the expected body shape", async () => {
+    let received: unknown = null;
+    server.use(
+      http.post(TELEMETRY_URL, async ({ request }) => {
+        received = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_command_executed", "550e8400-e29b-41d4-a716-446655440000", {
+      command: "search",
+      success: true,
+    });
+
+    expect(received).toEqual({
+      event: "dgrep_command_executed",
+      distinct_id: "550e8400-e29b-41d4-a716-446655440000",
+      properties: { command: "search", success: true },
+    });
+  });
+
+  it("resolves without throwing when the server returns an error", async () => {
+    server.use(
+      http.post(TELEMETRY_URL, () => new HttpResponse(null, { status: 500 })),
+    );
+
+    await expect(
+      track("dgrep_error", "550e8400-e29b-41d4-a716-446655440000", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves without throwing when the network fails", async () => {
+    server.use(http.post(TELEMETRY_URL, () => HttpResponse.error()));
+
+    await expect(
+      track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops when DO_NOT_TRACK=1", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+
+  it("no-ops when DO_NOT_TRACK is any non-empty, non-'0' value", async () => {
+    process.env.DO_NOT_TRACK = "true";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+
+  it("does NOT no-op when DO_NOT_TRACK='0'", async () => {
+    process.env.DO_NOT_TRACK = "0";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(true);
+  });
+
+  it("no-ops when DGREP_TELEMETRY=0", async () => {
+    process.env.DGREP_TELEMETRY = "0";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+});
+
+describe("isCI", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of CI_ENV_VARS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("returns false when no CI env vars are set", () => {
+    expect(isCI()).toBe(false);
+  });
+
+  it("returns true when CI=true", () => {
+    process.env.CI = "true";
+    expect(isCI()).toBe(true);
+  });
+
+  it("returns true when GITHUB_ACTIONS is set", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    expect(isCI()).toBe(true);
+  });
+
+  it("returns true when JENKINS_URL is set", () => {
+    process.env.JENKINS_URL = "http://jenkins.example.com";
+    expect(isCI()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `src/lib/telemetry/transport.ts` — the fire-and-forget POST transport for dgrep's anonymous opt-out telemetry. No SDK dependency, no third-party network connection from the CLI — the only network target is our own `api.docfork.com/v1/telemetry` endpoint.

## Context

First of 3 PRs that ship opt-out telemetry in dgrep (DOC-221). The module is unused until the schema ([#128](https://github.com/docfork/docfork/pull/128)) and wiring ([#129](https://github.com/docfork/docfork/pull/129)) land — nothing ships user-facing yet.

## What this ships

- **`src/lib/telemetry/transport.ts`** — `track(event, distinctId, properties)` does a fire-and-forget POST. Returns `Promise<void>` for tests; callers ignore the return.
- **Env-var opt-out at the transport layer:**
  - `DO_NOT_TRACK=<any non-empty, non-'0'>` (consoledonottrack.com convention)
  - `DGREP_TELEMETRY=0` (dgrep-specific override)
- **`isCI()`** — detects 8 standard CI env vars (CI, GITHUB_ACTIONS, GITLAB_CI, CIRCLECI, TRAVIS, BUILDKITE, JENKINS_URL, TEAMCITY_VERSION). Used by the first-run notice in a later PR to skip the 2s pause.
- **Config-based opt-out is NOT here** — that lands in a later PR (`telemetry-optout-notice`) alongside the `~/.dgrep/config.json` integration and the `dgrep telemetry {status,enable,disable}` subcommand.

## Test plan

- [x] 11 new tests in `test/lib/telemetry/transport.test.ts`: body shape, swallows server errors, swallows network errors, `DO_NOT_TRACK` truthy → no-op, `DO_NOT_TRACK='0'` → still fires, `DGREP_TELEMETRY=0` → no-op, `isCI()` detection for key env vars
- [x] `pnpm test` — all pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:check` — clean