### PR TITLE
feat(dgrep): define telemetry event schemas

### DIFF
--- a/packages/dgrep/src/lib/telemetry/events.ts
+++ b/packages/dgrep/src/lib/telemetry/events.ts
@@ -1,0 +1,47 @@
+import { track } from "./transport.js";
+
+export interface InstallProps {
+  os: string;
+  arch: string;
+  node_version: string;
+  dgrep_version: string;
+  install_id: string;
+  ci: boolean;
+}
+
+export interface CommandExecutedProps {
+  command: string;
+  success: boolean;
+  exit_code: number;
+  latency_ms: number;
+  flag_count: number;
+  json_mode: boolean;
+  authenticated: boolean;
+  dgrep_version: string;
+  node_version: string;
+  os: string;
+}
+
+export interface ErrorProps {
+  command: string;
+  error_class: string;
+  exit_code: number;
+  dgrep_version: string;
+  node_version: string;
+  os: string;
+}
+
+export function captureInstall(distinctId: string, props: InstallProps): Promise<void> {
+  return track("dgrep_install", distinctId, props as unknown as Record<string, unknown>);
+}
+
+export function captureCommandExecuted(
+  distinctId: string,
+  props: CommandExecutedProps,
+): Promise<void> {
+  return track("dgrep_command_executed", distinctId, props as unknown as Record<string, unknown>);
+}
+
+export function captureError(distinctId: string, props: ErrorProps): Promise<void> {
+  return track("dgrep_error", distinctId, props as unknown as Record<string, unknown>);
+}

--- a/packages/dgrep/src/lib/telemetry/events.ts
+++ b/packages/dgrep/src/lib/telemetry/events.ts
@@ -37,7 +37,7 @@ export function captureInstall(distinctId: string, props: InstallProps): Promise
 
 export function captureCommandExecuted(
   distinctId: string,
-  props: CommandExecutedProps,
+  props: CommandExecutedProps
 ): Promise<void> {
   return track("dgrep_command_executed", distinctId, props as unknown as Record<string, unknown>);
 }

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -1,6 +1,5 @@
 const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
 
-// Widely-set CI variables. Mirrors vercel-labs/add-skill.
 export function isCI(): boolean {
   return !!(
     process.env.CI ||
@@ -14,10 +13,10 @@ export function isCI(): boolean {
   );
 }
 
-// `DO_NOT_TRACK` is the consoledonottrack.com convention: any truthy value
-// opts the user out. `DGREP_TELEMETRY=0` is a dgrep-specific override so the
-// user can turn telemetry off without affecting other CLIs that honor
-// `DO_NOT_TRACK`. Config-based opt-out is layered on top by callers.
+// Two env vars. `DO_NOT_TRACK` opts the user out with any truthy value;
+// `DGREP_TELEMETRY=0` is a dgrep-specific override for users who want to
+// disable dgrep without affecting other tools on their machine.
+// Config-based opt-out is layered on top by callers.
 function envOptOut(): boolean {
   if (process.env.DO_NOT_TRACK && process.env.DO_NOT_TRACK !== "0") return true;
   if (process.env.DGREP_TELEMETRY === "0") return true;

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -1,0 +1,45 @@
+const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
+
+// Widely-set CI variables. Mirrors vercel-labs/add-skill.
+export function isCI(): boolean {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.TRAVIS ||
+    process.env.BUILDKITE ||
+    process.env.JENKINS_URL ||
+    process.env.TEAMCITY_VERSION
+  );
+}
+
+// `DO_NOT_TRACK` is the consoledonottrack.com convention: any truthy value
+// opts the user out. `DGREP_TELEMETRY=0` is a dgrep-specific override so the
+// user can turn telemetry off without affecting other CLIs that honor
+// `DO_NOT_TRACK`. Config-based opt-out is layered on top by callers.
+function envOptOut(): boolean {
+  if (process.env.DO_NOT_TRACK && process.env.DO_NOT_TRACK !== "0") return true;
+  if (process.env.DGREP_TELEMETRY === "0") return true;
+  return false;
+}
+
+export function track(
+  event: string,
+  distinctId: string,
+  properties: Record<string, unknown>,
+): Promise<void> {
+  if (envOptOut()) return Promise.resolve();
+  try {
+    return fetch(TELEMETRY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ event, distinct_id: distinctId, properties }),
+    }).then(
+      () => undefined,
+      () => undefined,
+    );
+  } catch {
+    return Promise.resolve();
+  }
+}

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -27,7 +27,7 @@ function envOptOut(): boolean {
 export function track(
   event: string,
   distinctId: string,
-  properties: Record<string, unknown>,
+  properties: Record<string, unknown>
 ): Promise<void> {
   if (envOptOut()) return Promise.resolve();
   try {
@@ -37,7 +37,7 @@ export function track(
       body: JSON.stringify({ event, distinct_id: distinctId, properties }),
     }).then(
       () => undefined,
-      () => undefined,
+      () => undefined
     );
   } catch {
     return Promise.resolve();

--- a/packages/dgrep/test/lib/telemetry/events.test.ts
+++ b/packages/dgrep/test/lib/telemetry/events.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import {
+  captureInstall,
+  captureCommandExecuted,
+  captureError,
+} from "../../../src/lib/telemetry/events.js";
+import { server } from "../../setup.js";
+
+const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
+const INSTALL_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+interface CapturedPayload {
+  event: string;
+  distinct_id: string;
+  properties: Record<string, unknown>;
+}
+
+function captureOnce(): () => CapturedPayload | null {
+  let received: CapturedPayload | null = null;
+  server.use(
+    http.post(TELEMETRY_URL, async ({ request }) => {
+      received = (await request.json()) as CapturedPayload;
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+  return () => received;
+}
+
+describe("captureInstall", () => {
+  // env-var opt-out tests live in transport.test.ts; here we only exercise
+  // the event shape, so clear both vars to avoid interference.
+  const saved = { DO_NOT_TRACK: process.env.DO_NOT_TRACK, DGREP_TELEMETRY: process.env.DGREP_TELEMETRY };
+  beforeEach(() => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.DGREP_TELEMETRY;
+  });
+  afterEach(() => {
+    if (saved.DO_NOT_TRACK !== undefined) process.env.DO_NOT_TRACK = saved.DO_NOT_TRACK;
+    if (saved.DGREP_TELEMETRY !== undefined) process.env.DGREP_TELEMETRY = saved.DGREP_TELEMETRY;
+  });
+
+  it("emits a dgrep_install event with the install props shape", async () => {
+    const get = captureOnce();
+    await captureInstall(INSTALL_ID, {
+      os: "darwin",
+      arch: "arm64",
+      node_version: "22.11.0",
+      dgrep_version: "0.2.0",
+      install_id: INSTALL_ID,
+      ci: false,
+    });
+    expect(get()).toEqual({
+      event: "dgrep_install",
+      distinct_id: INSTALL_ID,
+      properties: {
+        os: "darwin",
+        arch: "arm64",
+        node_version: "22.11.0",
+        dgrep_version: "0.2.0",
+        install_id: INSTALL_ID,
+        ci: false,
+      },
+    });
+  });
+
+  it("resolves when the server errors", async () => {
+    server.use(http.post(TELEMETRY_URL, () => new HttpResponse(null, { status: 500 })));
+    await expect(
+      captureInstall(INSTALL_ID, {
+        os: "linux",
+        arch: "x64",
+        node_version: "22.11.0",
+        dgrep_version: "0.2.0",
+        install_id: INSTALL_ID,
+        ci: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("captureCommandExecuted", () => {
+  beforeEach(() => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.DGREP_TELEMETRY;
+  });
+
+  it("emits a dgrep_command_executed event with the command props shape", async () => {
+    const get = captureOnce();
+    await captureCommandExecuted(INSTALL_ID, {
+      command: "search",
+      success: true,
+      exit_code: 0,
+      latency_ms: 123,
+      flag_count: 2,
+      json_mode: false,
+      authenticated: true,
+      dgrep_version: "0.2.0",
+      node_version: "22.11.0",
+      os: "darwin",
+    });
+    expect(get()).toEqual({
+      event: "dgrep_command_executed",
+      distinct_id: INSTALL_ID,
+      properties: {
+        command: "search",
+        success: true,
+        exit_code: 0,
+        latency_ms: 123,
+        flag_count: 2,
+        json_mode: false,
+        authenticated: true,
+        dgrep_version: "0.2.0",
+        node_version: "22.11.0",
+        os: "darwin",
+      },
+    });
+  });
+
+  it("resolves when the network fails", async () => {
+    server.use(http.post(TELEMETRY_URL, () => HttpResponse.error()));
+    await expect(
+      captureCommandExecuted(INSTALL_ID, {
+        command: "read",
+        success: false,
+        exit_code: 1,
+        latency_ms: 50,
+        flag_count: 0,
+        json_mode: true,
+        authenticated: false,
+        dgrep_version: "0.2.0",
+        node_version: "22.11.0",
+        os: "linux",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("captureError", () => {
+  beforeEach(() => {
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.DGREP_TELEMETRY;
+  });
+
+  it("emits a dgrep_error event with the error props shape", async () => {
+    const get = captureOnce();
+    await captureError(INSTALL_ID, {
+      command: "search",
+      error_class: "NetworkError",
+      exit_code: 1,
+      dgrep_version: "0.2.0",
+      node_version: "22.11.0",
+      os: "darwin",
+    });
+    expect(get()).toEqual({
+      event: "dgrep_error",
+      distinct_id: INSTALL_ID,
+      properties: {
+        command: "search",
+        error_class: "NetworkError",
+        exit_code: 1,
+        dgrep_version: "0.2.0",
+        node_version: "22.11.0",
+        os: "darwin",
+      },
+    });
+  });
+});

--- a/packages/dgrep/test/lib/telemetry/transport.test.ts
+++ b/packages/dgrep/test/lib/telemetry/transport.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { track, isCI } from "../../../src/lib/telemetry/transport.js";
+import { server } from "../../setup.js";
+
+const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
+
+const CI_ENV_VARS = [
+  "CI",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "CIRCLECI",
+  "TRAVIS",
+  "BUILDKITE",
+  "JENKINS_URL",
+  "TEAMCITY_VERSION",
+];
+
+describe("track", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ["DO_NOT_TRACK", "DGREP_TELEMETRY", ...CI_ENV_VARS]) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("POSTs to /v1/telemetry with the expected body shape", async () => {
+    let received: unknown = null;
+    server.use(
+      http.post(TELEMETRY_URL, async ({ request }) => {
+        received = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_command_executed", "550e8400-e29b-41d4-a716-446655440000", {
+      command: "search",
+      success: true,
+    });
+
+    expect(received).toEqual({
+      event: "dgrep_command_executed",
+      distinct_id: "550e8400-e29b-41d4-a716-446655440000",
+      properties: { command: "search", success: true },
+    });
+  });
+
+  it("resolves without throwing when the server returns an error", async () => {
+    server.use(
+      http.post(TELEMETRY_URL, () => new HttpResponse(null, { status: 500 })),
+    );
+
+    await expect(
+      track("dgrep_error", "550e8400-e29b-41d4-a716-446655440000", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves without throwing when the network fails", async () => {
+    server.use(http.post(TELEMETRY_URL, () => HttpResponse.error()));
+
+    await expect(
+      track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  it("no-ops when DO_NOT_TRACK=1", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+
+  it("no-ops when DO_NOT_TRACK is any non-empty, non-'0' value", async () => {
+    process.env.DO_NOT_TRACK = "true";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+
+  it("does NOT no-op when DO_NOT_TRACK='0'", async () => {
+    process.env.DO_NOT_TRACK = "0";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(true);
+  });
+
+  it("no-ops when DGREP_TELEMETRY=0", async () => {
+    process.env.DGREP_TELEMETRY = "0";
+    let called = false;
+    server.use(
+      http.post(TELEMETRY_URL, () => {
+        called = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_install", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(called).toBe(false);
+  });
+});
+
+describe("isCI", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of CI_ENV_VARS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("returns false when no CI env vars are set", () => {
+    expect(isCI()).toBe(false);
+  });
+
+  it("returns true when CI=true", () => {
+    process.env.CI = "true";
+    expect(isCI()).toBe(true);
+  });
+
+  it("returns true when GITHUB_ACTIONS is set", () => {
+    process.env.GITHUB_ACTIONS = "true";
+    expect(isCI()).toBe(true);
+  });
+
+  it("returns true when JENKINS_URL is set", () => {
+    process.env.JENKINS_URL = "http://jenkins.example.com";
+    expect(isCI()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds typed event definitions and capture helpers on top of the transport from [#127](https://github.com/docfork/docfork/pull/127). Three events:

- `dgrep_install` — fires once on first run
- `dgrep_command_executed` — fires after every command
- `dgrep_error` — fires when a command errors

## Context

Part of DOC-221. Second of 3 stacked PRs, built on [#127](https://github.com/docfork/docfork/pull/127).

**Stacked PR** — base branch is `telemetry-posthog-sdk`. When #127 merges, GitHub will prompt to retarget this PR to `main`.

## Property schema (audit-critical)

No query text, doc content, URLs, file paths, API keys, or cabinet names appear anywhere. `flag_count` is a number only — never per-flag booleans or values, since flag values may contain queries or paths.

## What this ships

- `src/lib/telemetry/events.ts` — interfaces (`InstallProps`, `CommandExecutedProps`, `ErrorProps`) + helper functions (`captureInstall`, `captureCommandExecuted`, `captureError`)
- Each helper calls `track(...)` from `transport.ts` — returns `Promise<void>` for testability, never throws
- Still not wired into any command — that lands in [#129](https://github.com/docfork/docfork/pull/129)

## Test plan

- [x] 5 new tests: shape assertions for all 3 events, network-failure swallowing, server-error swallowing
- [x] `pnpm test` — all pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:check` — clean