### PR TITLE
docs(dgrep): add Privacy & Telemetry README section (release 0.2.0)

### DIFF
--- a/packages/dgrep/README.md
+++ b/packages/dgrep/README.md
@@ -123,6 +123,22 @@ dgrep search "server actions with forms" -l vercel/next.js --json --yes
 dgrep read <url> --json
 ```
 
+## Privacy & telemetry
+
+dgrep sends anonymous usage events — command name, success/failure, latency — so we can see which commands people use and where the CLI fails.
+
+dgrep **never** sends query text, doc content, URLs, file paths, API keys, or cabinet names. The event schema and collector endpoint are open source; you can inspect the payload with any network tap.
+
+Opt out any of three ways:
+
+```bash
+dgrep telemetry disable   # persist to ~/.dgrep/config.json
+DO_NOT_TRACK=1            # session-wide, any CLI
+DGREP_TELEMETRY=0         # dgrep-specific
+```
+
+Details: [docfork.com/telemetry](https://docfork.com/telemetry).
+
 ## Links
 
 - [dgrep docs](https://docfork.com/docs/dgrep)


### PR DESCRIPTION
## Summary

Adds a "Privacy & Telemetry" section to the dgrep README and triggers a minor version bump to 0.2.0 via `Release-As: 0.2.0` in the commit footer.

## Why not a manual version bump?

Release-please handles the actual `package.json` bump and `CHANGELOG.md` regeneration when it cuts the release PR. Since dgrep is configured with `bump-patch-for-minor-pre-major: true` (see `release-please-config.json`), `feat:` commits normally bump patch in pre-1.0. The `Release-As:` footer forces release-please to publish 0.2.0 directly.

Supersedes #130 — single-commit history, no stale merge commits.

## Exit criteria (DOC-221)

After this merges and release-please publishes `dgrep@0.2.0`:

1. Verify on a fresh install:
   - First-run notice appears on interactive TTY
   - `dgrep_install`, `dgrep_command_executed`, `dgrep_error` events arrive at the collector
   - `X-Docfork-Client: dgrep/0.2.0` present on server logs
   - `DO_NOT_TRACK=1` → zero collector requests
   - `/telemetry` page at https://docfork.com/telemetry renders