### PR TITLE
chore: block npm install at monorepo root via preinstall guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Docfork monorepo",
   "type": "module",
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "start": "turbo run start",


### PR DESCRIPTION
## Summary
- Adds `"preinstall": "npx only-allow pnpm"` to the root `package.json` so `npm install` / `yarn install` at the repo root hard-fail instead of silently proceeding with warnings about pnpm-only keys in `.npmrc` (`shamefully-hoist`, `strict-peer-dependencies`, `auto-install-peers`).
- Standalone `npm install` inside `packages/mcp/` is unaffected — npm does not climb directories for `preinstall` scripts, and `packages/mcp/.npmrc` has no pnpm-only keys.
- The release pipeline's `npx npm@latest publish` calls are also unaffected (`only-allow` runs on install, not publish).

## Test plan
- [ ] `pnpm install` at repo root still succeeds
- [ ] `npm install` at repo root exits with an `only-allow pnpm` error
- [ ] `pnpm lint:check && pnpm typecheck && pnpm build` green
- [ ] CI green (existing `ci.yml` exercises the full install path)