### PR TITLE
feat(dgrep): send X-Docfork-Client header on /v1/telemetry POST [DOC-227 PR 3.2]

### DIFF
--- a/packages/dgrep/CHANGELOG.md
+++ b/packages/dgrep/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Send `X-Docfork-Client: dgrep/<version>` header on telemetry POSTs for server-side consistency with real-API traffic (previously only set on API calls, not /v1/telemetry).
+
 ## [0.2.0](https://github.com/docfork/docfork/compare/dgrep-v0.1.2...dgrep-v0.2.0) (2026-04-17)
 
 

--- a/packages/dgrep/package.json
+++ b/packages/dgrep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgrep",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The Context CLI for AI Agents",
   "type": "module",
   "bin": {

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -1,3 +1,5 @@
+import { VERSION } from "../version.js";
+
 const TELEMETRY_URL = "https://api.docfork.com/v1/telemetry";
 
 export function isCI(): boolean {
@@ -32,7 +34,10 @@ export function track(
   try {
     return fetch(TELEMETRY_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Docfork-Client": `dgrep/${VERSION}`,
+      },
       body: JSON.stringify({ event, distinct_id: distinctId, properties }),
     }).then(
       () => undefined,

--- a/packages/dgrep/src/lib/telemetry/transport.ts
+++ b/packages/dgrep/src/lib/telemetry/transport.ts
@@ -36,7 +36,10 @@ export function track(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Docfork-Client": `dgrep/${VERSION}`,
+        // `?? "unknown"` keeps the emission readable if the VERSION import
+        // ever regresses (build glitch, circular import) instead of
+        // silently poisoning attribution with "dgrep/undefined".
+        "X-Docfork-Client": `dgrep/${VERSION ?? "unknown"}`,
       },
       body: JSON.stringify({ event, distinct_id: distinctId, properties }),
     }).then(

--- a/packages/dgrep/test/lib/telemetry/transport.test.ts
+++ b/packages/dgrep/test/lib/telemetry/transport.test.ts
@@ -54,6 +54,20 @@ describe("track", () => {
     });
   });
 
+  it("sends X-Docfork-Client header so the backend can tag client_surface from the header", async () => {
+    let clientHeader: string | null = null;
+    server.use(
+      http.post(TELEMETRY_URL, ({ request }) => {
+        clientHeader = request.headers.get("x-docfork-client");
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await track("dgrep_command_executed", "550e8400-e29b-41d4-a716-446655440000", {});
+
+    expect(clientHeader).toMatch(/^dgrep\/\d+\.\d+\.\d+/);
+  });
+
   it("resolves without throwing when the server returns an error", async () => {
     server.use(
       http.post(TELEMETRY_URL, () => new HttpResponse(null, { status: 500 })),


### PR DESCRIPTION
## Why

`X-Docfork-Client: dgrep/<version>` is already set on every real API call (`/v1/search`, `/v1/read`, etc.) via `packages/dgrep/src/lib/api-client.ts`. It was not being sent on the `/v1/telemetry` POST — the upstream service fell back to inferring the client identity from the event-name prefix.

Adding the header on the telemetry POST means the upstream can tag the client surface from a single source of truth, same as real-API traffic. Cleaner data model, less string-sniffing.

## What

- Bump `packages/dgrep` 0.2.0 → 0.2.1 (patch — observational-only metadata).
- `src/lib/telemetry/transport.ts`: import `VERSION` from `../version.js` (same source `api-client.ts` uses) and add `X-Docfork-Client: dgrep/${VERSION}` to the POST headers.
- Extend `test/lib/telemetry/transport.test.ts` to assert the header is present on the outbound POST.
- CHANGELOG entry.

Body shape (`{ event, distinct_id, properties }`) is unchanged. dgrep 0.2.0 is already live posting to this endpoint, and backward compatibility is preserved.

## Impact

- Zero behavior change for CLI users — header is purely observational metadata.
- Backward compatible — older dgrep installs (0.2.0 already in the wild) continue to work unchanged.
- Patch bump rationale: observational-only semantic, no user-visible behavior change.

## Test plan

- [x] `pnpm --filter dgrep test` — 134 tests pass, including new header assertion.
- [x] `pnpm --filter dgrep typecheck` — clean.
- [x] `pnpm --filter dgrep run lint` — clean.

## Post-merge runbook

1. Merge this PR.
2. release-please picks up 0.2.1 via its usual workflow (or `pnpm --filter dgrep run build && cd packages/dgrep && npm publish --access public` if running manually).

---
Part of [DOC-227](https://linear.app/docfork/issue/DOC-227).
