### PR TITLE
feat(mcp): emit X-Docfork-Client header for cross-surface tagging [DOC-227 PR 3.1]

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1
+
+- Add `X-Docfork-Client: mcp-server/<version>` header on backend requests so PostHog events can tag `client_surface="mcp-server"` (previously relied on header-absence inference).
+
 ## [2.2.0](https://github.com/docfork/docfork/compare/docfork-v2.1.0...docfork-v2.2.0) (2026-04-14)
 
 

--- a/packages/mcp/gemini-extension.json
+++ b/packages/mcp/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "docfork",
   "description": "Up-to-date code documentation for AI agents.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "mcpServers": {
     "docfork": {
       "command": "node",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docfork",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Up-to-date code documentation for AI agents.",
   "mcpName": "io.github.docfork/docfork",
   "type": "module",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/docfork/docfork",
     "source": "github"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "remotes": [
     {
       "type": "streamable-http",
@@ -37,7 +37,7 @@
     {
       "registryType": "npm",
       "identifier": "docfork",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/api/headers.ts
+++ b/packages/mcp/src/api/headers.ts
@@ -1,4 +1,5 @@
 import { DocforkAuthConfig } from "../config.js";
+import { SERVER_VERSION } from "../lib/constants.js";
 import { encryptClientIp } from "../lib/encryption.js";
 
 /**
@@ -10,6 +11,11 @@ export function generateHeaders(auth?: DocforkAuthConfig): Record<string, string
     "User-Agent": "docfork-mcp",
     "Content-Type": "application/json",
     accept: "application/json",
+    // Identifies the client surface to the backend. Backend tags PostHog
+    // events with client_surface="mcp-server" based on this header; the
+    // forwarded X-Docfork-Client-Info below carries the upstream IDE
+    // (Cursor, Claude Desktop, Inspector) as upstream_client.
+    "X-Docfork-Client": `mcp-server/${SERVER_VERSION}`,
   };
 
   if (auth?.clientInfo) {

--- a/packages/mcp/src/api/headers.ts
+++ b/packages/mcp/src/api/headers.ts
@@ -15,7 +15,12 @@ export function generateHeaders(auth?: DocforkAuthConfig): Record<string, string
     // events with client_surface="mcp-server" based on this header; the
     // forwarded X-Docfork-Client-Info below carries the upstream IDE
     // (Cursor, Claude Desktop, Inspector) as upstream_client.
-    "X-Docfork-Client": `mcp-server/${SERVER_VERSION}`,
+    //
+    // `?? "unknown"` keeps the emission readable if SERVER_VERSION ever
+    // regresses (version loader glitch, extra-files drift across
+    // package.json/server.json/gemini-extension.json) instead of
+    // silently poisoning attribution with "mcp-server/undefined".
+    "X-Docfork-Client": `mcp-server/${SERVER_VERSION ?? "unknown"}`,
   };
 
   if (auth?.clientInfo) {


### PR DESCRIPTION
## Why

The upstream API service reads an `X-Docfork-Client` header to identify which client originated a request. The MCP server currently sends `X-Docfork-Client-Info` (the forwarded upstream user-agent — Cursor, Claude Desktop, Inspector) but not `X-Docfork-Client` identifying itself as the MCP server. Without this PR the upstream falls back to treating MCP traffic as unknown; with it, analytics can cleanly break down MCP traffic by IDE via the pair `X-Docfork-Client: mcp-server/<version>` + `X-Docfork-Client-Info: <upstream IDE>`.

## What

- Bump `packages/mcp` 2.2.0 → 2.2.1 (patch — observational-only metadata).
- `src/api/headers.ts`: import the existing `SERVER_VERSION` const from `lib/constants.ts` (same source already used elsewhere) and add `"X-Docfork-Client": \`mcp-server/${SERVER_VERSION}\`` to the outbound header map. `X-Docfork-Client-Info` stays untouched.
- CHANGELOG entry.
- Sync `server.json` + `gemini-extension.json` versions (wired via release-please `extra-files`).

## Impact

- Zero behavior change for MCP consumers; purely additive header.
- Backward compatible — clients on older versions continue to work unchanged.
- Patch bump rationale: observational-only semantic, no user-visible behavior change.

## Test plan

- [x] `pnpm --filter docfork run typecheck` — clean.
- [x] `pnpm --filter docfork run lint:check` — clean.
- [x] `pnpm --filter docfork run format:check` — clean.

Note: `packages/mcp` currently has no test harness (`"test"` is an echo stub; no vitest/node-test in deps). Adding a header-assertion test would require introducing a framework — out of scope for a patch bump. Worth a follow-up issue to bring MCP to parity with dgrep's vitest+msw coverage.

## Post-merge runbook

1. Merge this PR.
2. release-please picks up 2.2.1 via its usual workflow (extra-files auto-syncs `server.json` + `gemini-extension.json`).
3. Pin the MCP deployment to 2.2.1 after publish.

---
Part of [DOC-227](https://linear.app/docfork/issue/DOC-227).
