### PR TITLE
feat(mcp): capture mcp_initialize and mcp_tool_call server-side

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1208,6 +1208,28 @@ Free: 1,000 requests/month. Share API keys and Cabinets across your organization
 
 Docfork is retrieval, not synthesis — agents compose the answers.
 
+## Privacy & telemetry
+
+The MCP server sends anonymous usage events — client name, tool name, and whether each call succeeded — so we can see which clients connect and where the server fails.
+
+The MCP server **never** sends query text, library names, result content, URLs, raw API keys, or IP addresses. The plugin and CLI clients ship no telemetry of their own — the server is the only emitter, and its source is open for inspection.
+
+Opt out any of four ways:
+
+```bash
+DO_NOT_TRACK=1            # universal standard, any tool
+DOCFORK_TELEMETRY=0       # docfork-specific
+```
+
+Per-request opt-out for the hosted server (`mcp.docfork.com`):
+
+```
+DNT: 1
+X-Docfork-Telemetry: 0
+```
+
+Any one signal short-circuits before the network call. Details: [docfork.com/telemetry](https://docfork.com/telemetry).
+
 ## Community
 
 - **[Changelog](https://docfork.com/changelog)** – We ship constantly. Every release, documented.

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -84,6 +84,8 @@ export interface DocforkAuthConfig {
   clientIp?: string;
   clientInfo?: string;
   transport: "stdio" | "http";
+  // per-request telemetry opt-out, sourced from DNT/X-Docfork-Telemetry headers on http
+  telemetryOptOut?: boolean;
 }
 
 /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -20,20 +20,13 @@ import {
 import { startHttpServer, startStdioServer } from "./transport.js";
 import { captureMcpToolCall } from "./lib/analytics.js";
 
-// classify errors into stable buckets so the dashboard doesn't explode on stack traces
-function errorKindOf(e: unknown): string {
-  if (e instanceof Error) return e.name || "Error";
-  return typeof e;
-}
-
-// wrap a tool handler so duration + outcome ship to analytics regardless of transport
+// wrap a tool handler so every call ships to telemetry regardless of transport
 function instrumentTool<TArgs, TResult>(
   toolName: string,
   handler: (args: TArgs) => Promise<TResult>
 ): (args: TArgs) => Promise<TResult> {
   return async (args: TArgs) => {
     const auth = getAuthConfig();
-    const start = performance.now();
     try {
       const result = await handler(args);
       captureMcpToolCall({
@@ -41,9 +34,8 @@ function instrumentTool<TArgs, TResult>(
         clientIp: auth?.clientIp,
         clientInfoHeader: auth?.clientInfo,
         toolName,
-        durationMs: performance.now() - start,
-        ok: true,
         transport: auth?.transport === "http" ? "http" : "stdio",
+        optOut: auth?.telemetryOptOut,
       });
       return result;
     } catch (e) {
@@ -52,10 +44,8 @@ function instrumentTool<TArgs, TResult>(
         clientIp: auth?.clientIp,
         clientInfoHeader: auth?.clientInfo,
         toolName,
-        durationMs: performance.now() - start,
-        ok: false,
-        errorKind: errorKindOf(e),
         transport: auth?.transport === "http" ? "http" : "stdio",
+        optOut: auth?.telemetryOptOut,
       });
       throw e;
     }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -18,6 +18,49 @@ import {
   getAuthConfig,
 } from "./config.js";
 import { startHttpServer, startStdioServer } from "./transport.js";
+import { captureMcpToolCall } from "./lib/analytics.js";
+
+// classify errors into stable buckets so the dashboard doesn't explode on stack traces
+function errorKindOf(e: unknown): string {
+  if (e instanceof Error) return e.name || "Error";
+  return typeof e;
+}
+
+// wrap a tool handler so duration + outcome ship to analytics regardless of transport
+function instrumentTool<TArgs, TResult>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<TResult>
+): (args: TArgs) => Promise<TResult> {
+  return async (args: TArgs) => {
+    const auth = getAuthConfig();
+    const start = performance.now();
+    try {
+      const result = await handler(args);
+      captureMcpToolCall({
+        apiKey: auth?.apiKey,
+        clientIp: auth?.clientIp,
+        clientInfoHeader: auth?.clientInfo,
+        toolName,
+        durationMs: performance.now() - start,
+        ok: true,
+        transport: auth?.transport === "http" ? "http" : "stdio",
+      });
+      return result;
+    } catch (e) {
+      captureMcpToolCall({
+        apiKey: auth?.apiKey,
+        clientIp: auth?.clientIp,
+        clientInfoHeader: auth?.clientInfo,
+        toolName,
+        durationMs: performance.now() - start,
+        ok: false,
+        errorKind: errorKindOf(e),
+        transport: auth?.transport === "http" ? "http" : "stdio",
+      });
+      throw e;
+    }
+  };
+}
 
 /**
  * Create and configure the standard MCP server
@@ -89,7 +132,7 @@ Usage:
         readOnlyHint: true,
       },
     },
-    async ({ query, tokens, library }): Promise<CallToolResult> => {
+    instrumentTool("search_docs", async ({ query, tokens, library }): Promise<CallToolResult> => {
       const authConfig = getAuthConfig();
       const tokensParam =
         typeof tokens === "number" ? String(tokens) : (tokens as string | undefined);
@@ -130,7 +173,7 @@ Usage:
           },
         ],
       };
-    }
+    })
   );
 
   // register docfork fetch doc tool
@@ -157,7 +200,7 @@ Retrieve full documentation content from a URL and return it as rendered markdow
         readOnlyHint: true,
       },
     },
-    async (args): Promise<CallToolResult> => {
+    instrumentTool("fetch_doc", async (args): Promise<CallToolResult> => {
       const inputValue = args.url as string;
       const authConfig = getAuthConfig();
       const response = await readUrl(inputValue, authConfig);
@@ -169,7 +212,7 @@ Retrieve full documentation content from a URL and return it as rendered markdow
           },
         ],
       };
-    }
+    })
   );
 
   // Error handler

--- a/packages/mcp/src/lib/analytics.ts
+++ b/packages/mcp/src/lib/analytics.ts
@@ -78,10 +78,7 @@ function normalizeClientName(name?: string): string {
 }
 
 // best-effort client name from MCP clientInfo (initialize) or user-agent header
-function clientNameFrom(
-  rawClientInfo?: { name?: string },
-  clientInfoHeader?: string
-): string {
+function clientNameFrom(rawClientInfo?: { name?: string }, clientInfoHeader?: string): string {
   if (rawClientInfo?.name) return normalizeClientName(rawClientInfo.name);
   if (clientInfoHeader) {
     // user-agent shapes like "claude-code/1.2.3 (...)" — first token before "/"

--- a/packages/mcp/src/lib/analytics.ts
+++ b/packages/mcp/src/lib/analytics.ts
@@ -1,11 +1,14 @@
 import { createHash } from "crypto";
-import { SERVER_VERSION } from "./constants.js";
+import { API_URL, SERVER_VERSION } from "./constants.js";
 
-// server-side mcp analytics. fire-and-forget posthog capture.
-// no-op unless POSTHOG_API_KEY is set (prod) or DOCFORK_ANALYTICS_DEBUG=1 (local test).
-// client repos (plugin, cli) ship no telemetry; the server is the only emitter.
+// server-side mcp telemetry. fire-and-forget POST to api.docfork.com/v1/telemetry.
+// public client repos (plugin, cli) ship no telemetry; the server is the only emitter.
+// the relay endpoint forwards to posthog server-side so this package contains no
+// posthog reference and no secrets.
 
-const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const TELEMETRY_URL = `${API_URL}/telemetry`;
+const TELEMETRY_TIMEOUT_MS = 2000;
+
 const ALLOWED_CLIENTS = new Set([
   "claude-code",
   "claude-desktop",
@@ -28,6 +31,7 @@ interface InitializeArgs {
   rawClientInfo?: { name?: string; version?: string };
   protocolVersion?: string;
   transport: "http" | "stdio";
+  optOut?: boolean;
 }
 
 interface ToolCallArgs {
@@ -35,29 +39,24 @@ interface ToolCallArgs {
   clientIp?: string;
   clientInfoHeader?: string;
   toolName: string;
-  durationMs: number;
-  ok: boolean;
-  errorKind?: string;
   transport: "http" | "stdio";
+  optOut?: boolean;
 }
 
 function isDebug(): boolean {
   return process.env.DOCFORK_ANALYTICS_DEBUG === "1";
 }
 
-function projectKey(): string | undefined {
-  return process.env.POSTHOG_API_KEY || process.env.POSTHOG_PROJECT_API_KEY;
-}
-
-function host(): string {
-  return process.env.POSTHOG_HOST || DEFAULT_POSTHOG_HOST;
-}
-
-function enabled(): boolean {
-  return isDebug() || Boolean(projectKey());
+// universal "do not track" standard (consoledonottrack.com) + a tool-specific
+// override so users can disable docfork without touching unrelated tools.
+function envOptOut(): boolean {
+  if (process.env.DO_NOT_TRACK && process.env.DO_NOT_TRACK !== "0") return true;
+  if (process.env.DOCFORK_TELEMETRY === "0") return true;
+  return false;
 }
 
 // stable, non-reversible id derived from api key. falls back to ip-derived anon id.
+// hashed prefix shape (`u_*` / `anon_*`) is what the relay accepts for non-uuid clients.
 function distinctId(apiKey?: string, clientIp?: string): string {
   if (apiKey) {
     return "u_" + createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
@@ -68,7 +67,7 @@ function distinctId(apiKey?: string, clientIp?: string): string {
   return "anon_unknown";
 }
 
-// allowlist-fold cardinality so the dashboard stays readable
+// allowlist-fold cardinality so dashboards stay readable
 function normalizeClientName(name?: string): string {
   if (!name) return "unknown";
   const lower = name.toLowerCase().trim();
@@ -82,60 +81,51 @@ function normalizeClientName(name?: string): string {
 function clientNameFrom(
   rawClientInfo?: { name?: string },
   clientInfoHeader?: string
-): { name: string; raw?: string } {
-  if (rawClientInfo?.name) {
-    return { name: normalizeClientName(rawClientInfo.name), raw: rawClientInfo.name };
-  }
+): string {
+  if (rawClientInfo?.name) return normalizeClientName(rawClientInfo.name);
   if (clientInfoHeader) {
     // user-agent shapes like "claude-code/1.2.3 (...)" — first token before "/"
     const token = clientInfoHeader.split(/[/\s]/)[0];
-    return { name: normalizeClientName(token), raw: clientInfoHeader };
+    return normalizeClientName(token);
   }
-  return { name: "unknown" };
+  return "unknown";
 }
 
-async function send(event: string, distinct_id: string, properties: Record<string, unknown>) {
-  if (!enabled()) return;
+async function send(
+  event: string,
+  distinct_id: string,
+  properties: Record<string, unknown>
+): Promise<void> {
+  if (envOptOut()) return;
 
-  const payload = {
-    api_key: projectKey() || "debug",
-    event,
-    distinct_id,
-    properties: {
-      ...properties,
-      $lib: "docfork-mcp-server",
-      $lib_version: SERVER_VERSION,
-    },
-    timestamp: new Date().toISOString(),
-  };
+  const payload = { event, distinct_id, properties };
 
   if (isDebug()) {
     process.stderr.write(`[analytics] ${event} ${JSON.stringify(payload)}\n`);
+    return; // debug mode skips network so local runs don't spam prod telemetry
   }
 
-  if (!projectKey()) return;
-
-  // fire-and-forget. swallow all errors so analytics never breaks a tool call.
+  // fire-and-forget. swallow all errors so telemetry never breaks a tool call.
   try {
-    await fetch(`${host()}/capture/`, {
+    await fetch(TELEMETRY_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Docfork-Client": `docfork-mcp/${SERVER_VERSION}`,
+      },
       body: JSON.stringify(payload),
-      // short timeout so a slow posthog never tail-latencies a tool response
-      signal: AbortSignal.timeout(2000),
+      signal: AbortSignal.timeout(TELEMETRY_TIMEOUT_MS),
     });
   } catch {
-    // intentional: never let analytics raise
+    // intentional: never let telemetry raise
   }
 }
 
 export function captureMcpInitialize(args: InitializeArgs): void {
-  if (!enabled()) return;
+  if (args.optOut || envOptOut()) return;
 
-  const { name, raw } = clientNameFrom(args.rawClientInfo, args.clientInfoHeader);
   const properties = {
-    client_name: name,
-    client_name_raw: raw,
+    client_name: clientNameFrom(args.rawClientInfo, args.clientInfoHeader),
     client_version: args.rawClientInfo?.version,
     protocol_version: args.protocolVersion,
     transport: args.transport,
@@ -143,24 +133,19 @@ export function captureMcpInitialize(args: InitializeArgs): void {
     has_api_key: Boolean(args.apiKey),
   };
 
-  // not awaited: fire-and-forget
   void send("mcp_initialize", distinctId(args.apiKey, args.clientIp), properties);
 }
 
 export function captureMcpToolCall(args: ToolCallArgs): void {
-  if (!enabled()) return;
+  if (args.optOut || envOptOut()) return;
 
-  const { name } = clientNameFrom(undefined, args.clientInfoHeader);
+  // shape matches /v1/telemetry allowlist for mcp_tool_called: only
+  // tool_name, upstream_client, and org_id are forwarded. org_id is
+  // resolved by the relay from the calling api key, not by this package.
   const properties = {
     tool_name: args.toolName,
-    duration_ms: Math.round(args.durationMs),
-    ok: args.ok,
-    error_kind: args.errorKind,
-    client_name: name,
-    transport: args.transport,
-    server_version: SERVER_VERSION,
-    has_api_key: Boolean(args.apiKey),
+    upstream_client: clientNameFrom(undefined, args.clientInfoHeader),
   };
 
-  void send("mcp_tool_call", distinctId(args.apiKey, args.clientIp), properties);
+  void send("mcp_tool_called", distinctId(args.apiKey, args.clientIp), properties);
 }

--- a/packages/mcp/src/lib/analytics.ts
+++ b/packages/mcp/src/lib/analytics.ts
@@ -1,0 +1,166 @@
+import { createHash } from "crypto";
+import { SERVER_VERSION } from "./constants.js";
+
+// server-side mcp analytics. fire-and-forget posthog capture.
+// no-op unless POSTHOG_API_KEY is set (prod) or DOCFORK_ANALYTICS_DEBUG=1 (local test).
+// client repos (plugin, cli) ship no telemetry; the server is the only emitter.
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const ALLOWED_CLIENTS = new Set([
+  "claude-code",
+  "claude-desktop",
+  "cursor",
+  "zed",
+  "windsurf",
+  "vscode",
+  "continue",
+  "cline",
+  "mcp-inspector",
+  "inspector-client",
+  "docfork-plugin",
+  "dgrep",
+]);
+
+interface InitializeArgs {
+  apiKey?: string;
+  clientIp?: string;
+  clientInfoHeader?: string;
+  rawClientInfo?: { name?: string; version?: string };
+  protocolVersion?: string;
+  transport: "http" | "stdio";
+}
+
+interface ToolCallArgs {
+  apiKey?: string;
+  clientIp?: string;
+  clientInfoHeader?: string;
+  toolName: string;
+  durationMs: number;
+  ok: boolean;
+  errorKind?: string;
+  transport: "http" | "stdio";
+}
+
+function isDebug(): boolean {
+  return process.env.DOCFORK_ANALYTICS_DEBUG === "1";
+}
+
+function projectKey(): string | undefined {
+  return process.env.POSTHOG_API_KEY || process.env.POSTHOG_PROJECT_API_KEY;
+}
+
+function host(): string {
+  return process.env.POSTHOG_HOST || DEFAULT_POSTHOG_HOST;
+}
+
+function enabled(): boolean {
+  return isDebug() || Boolean(projectKey());
+}
+
+// stable, non-reversible id derived from api key. falls back to ip-derived anon id.
+function distinctId(apiKey?: string, clientIp?: string): string {
+  if (apiKey) {
+    return "u_" + createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+  }
+  if (clientIp) {
+    return "anon_" + createHash("sha256").update(clientIp).digest("hex").slice(0, 16);
+  }
+  return "anon_unknown";
+}
+
+// allowlist-fold cardinality so the dashboard stays readable
+function normalizeClientName(name?: string): string {
+  if (!name) return "unknown";
+  const lower = name.toLowerCase().trim();
+  for (const known of ALLOWED_CLIENTS) {
+    if (lower === known || lower.includes(known)) return known;
+  }
+  return "other";
+}
+
+// best-effort client name from MCP clientInfo (initialize) or user-agent header
+function clientNameFrom(
+  rawClientInfo?: { name?: string },
+  clientInfoHeader?: string
+): { name: string; raw?: string } {
+  if (rawClientInfo?.name) {
+    return { name: normalizeClientName(rawClientInfo.name), raw: rawClientInfo.name };
+  }
+  if (clientInfoHeader) {
+    // user-agent shapes like "claude-code/1.2.3 (...)" — first token before "/"
+    const token = clientInfoHeader.split(/[/\s]/)[0];
+    return { name: normalizeClientName(token), raw: clientInfoHeader };
+  }
+  return { name: "unknown" };
+}
+
+async function send(event: string, distinct_id: string, properties: Record<string, unknown>) {
+  if (!enabled()) return;
+
+  const payload = {
+    api_key: projectKey() || "debug",
+    event,
+    distinct_id,
+    properties: {
+      ...properties,
+      $lib: "docfork-mcp-server",
+      $lib_version: SERVER_VERSION,
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  if (isDebug()) {
+    process.stderr.write(`[analytics] ${event} ${JSON.stringify(payload)}\n`);
+  }
+
+  if (!projectKey()) return;
+
+  // fire-and-forget. swallow all errors so analytics never breaks a tool call.
+  try {
+    await fetch(`${host()}/capture/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      // short timeout so a slow posthog never tail-latencies a tool response
+      signal: AbortSignal.timeout(2000),
+    });
+  } catch {
+    // intentional: never let analytics raise
+  }
+}
+
+export function captureMcpInitialize(args: InitializeArgs): void {
+  if (!enabled()) return;
+
+  const { name, raw } = clientNameFrom(args.rawClientInfo, args.clientInfoHeader);
+  const properties = {
+    client_name: name,
+    client_name_raw: raw,
+    client_version: args.rawClientInfo?.version,
+    protocol_version: args.protocolVersion,
+    transport: args.transport,
+    server_version: SERVER_VERSION,
+    has_api_key: Boolean(args.apiKey),
+  };
+
+  // not awaited: fire-and-forget
+  void send("mcp_initialize", distinctId(args.apiKey, args.clientIp), properties);
+}
+
+export function captureMcpToolCall(args: ToolCallArgs): void {
+  if (!enabled()) return;
+
+  const { name } = clientNameFrom(undefined, args.clientInfoHeader);
+  const properties = {
+    tool_name: args.toolName,
+    duration_ms: Math.round(args.durationMs),
+    ok: args.ok,
+    error_kind: args.errorKind,
+    client_name: name,
+    transport: args.transport,
+    server_version: SERVER_VERSION,
+    has_api_key: Boolean(args.apiKey),
+  };
+
+  void send("mcp_tool_call", distinctId(args.apiKey, args.clientIp), properties);
+}

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -218,12 +218,19 @@ export async function startHttpServer(
         try {
           const userAgent =
             typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : undefined;
+          // DNT=1 or X-Docfork-Telemetry=0 opts the caller out of telemetry per-request
+          const dnt = req.headers["dnt"];
+          const dfTelemetry = req.headers["x-docfork-telemetry"];
+          const telemetryOptOut =
+            (typeof dnt === "string" && dnt === "1") ||
+            (typeof dfTelemetry === "string" && dfTelemetry === "0");
           authConfig = {
             ...extractAuthConfigFromRequest(req),
             clientIp: getClientIp(req),
             // forward client user-agent to api for attribution and debugging
             clientInfo: userAgent,
             transport: "http",
+            telemetryOptOut,
           };
         } catch (error: any) {
           sendJsonError(res, 400, -32602, error.message || "Invalid configuration");
@@ -298,6 +305,7 @@ export async function startHttpServer(
               rawClientInfo: requestBody?.params?.clientInfo,
               protocolVersion: requestBody?.params?.protocolVersion,
               transport: "http",
+              optOut: authConfig.telemetryOptOut,
             });
           }
 

--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { DocforkAuthConfig, resolveAuthConfig, authContext } from "./config.js";
 import { isJwt, validateJwt, shouldTrustProxyHeaders } from "./lib/jwt.js";
+import { captureMcpInitialize } from "./lib/analytics.js";
 
 const maxRequestBodyBytes = 1_000_000;
 
@@ -285,11 +286,19 @@ export async function startHttpServer(
         }
 
         try {
-          // Only log client info on first connection (initialize request)
+          // log + capture client info on initialize handshake
           const isInitialize = requestBody?.method === "initialize";
           if (isInitialize) {
             const clientType = detectClientType(requestBody);
             console.log(`Client info: ${clientType}`);
+            captureMcpInitialize({
+              apiKey: authConfig.apiKey,
+              clientIp: authConfig.clientIp,
+              clientInfoHeader: authConfig.clientInfo,
+              rawClientInfo: requestBody?.params?.clientInfo,
+              protocolVersion: requestBody?.params?.protocolVersion,
+              transport: "http",
+            });
           }
 
           const serverFactory = standardServerFactory;


### PR DESCRIPTION
## Summary

Server-side MCP telemetry. Public client surfaces (plugin, CLI) ship no telemetry; the MCP server fires fire-and-forget POSTs to the existing `api.docfork.com/v1/telemetry` relay endpoint that already serves dgrep + marketing. No PostHog reference in this package, no secret-key management on the MCP deploy.

## Architecture

```
docfork (mcp server) ──► api.docfork.com/v1/telemetry ──► PostHog
                          (allowlists events + props,
                           resolves org_id, holds the
                           project key)
```

Mirrors the pattern established in `packages/dgrep/src/lib/telemetry/transport.ts`. The relay endpoint (`apps/api-v2/src/routes/telemetry.ts` on the backend) already accepts `mcp_tool_called` in its allowlist — this PR is purely the client-side emitter.

## Files

- `src/lib/analytics.ts` (new) — `captureMcpInitialize` + `captureMcpToolCall`. SHA-256-hashed `distinct_id`, allowlisted client_name fold, 2s timeout, all errors swallowed.
- `src/transport.ts` — emits on HTTP `initialize` handshake; reads `DNT` + `X-Docfork-Telemetry` headers per request and propagates onto `authConfig.telemetryOptOut`.
- `src/index.ts` — `instrumentTool` wraps `search_docs` + `fetch_doc`. One wrapper covers HTTP + stdio.
- `src/config.ts` — adds `telemetryOptOut?: boolean` to `DocforkAuthConfig`.

## Opt-out (catch-all)

Any one signal short-circuits before the network call:

| Signal | Scope | Notes |
|---|---|---|
| `DO_NOT_TRACK` env (any truthy value) | stdio + HTTP server operator | consoledonottrack.com standard |
| `DOCFORK_TELEMETRY=0` env | stdio + HTTP server operator | tool-specific override |
| `DNT: 1` request header | HTTP, per-request | W3C standard |
| `X-Docfork-Telemetry: 0` request header | HTTP, per-request | explicit |

`DOCFORK_ANALYTICS_DEBUG=1` enables stderr `[analytics] <event> <payload>` logging and skips the network entirely — for local verification without spamming the relay.

## Wire shape

```
POST https://api.docfork.com/v1/telemetry
X-Docfork-Client: docfork-mcp/2.2.1

{
  "event": "mcp_tool_called",
  "distinct_id": "u_<sha256-prefix>" | "anon_<sha256-prefix>",
  "properties": { "tool_name": "search_docs", "upstream_client": "claude-code" }
}
```

`mcp_initialize` events are also emitted with richer properties (client_name, client_version, protocol_version, transport, server_version, has_api_key). The relay's allowlist currently rejects unknown events; these requests are silently dropped server-side until the backend allowlist is extended in a follow-up. Forward-compatible — no MCP-side change needed when that lands.

## Test plan

Verified locally with `DOCFORK_ANALYTICS_DEBUG=1 MCP_TRANSPORT=streamable-http node dist/index.js` and curl:

- [x] `initialize` from `claude-code/1.4.2` → `mcp_initialize` debug line, correct distinct_id + props
- [x] `tools/call search_docs` with `User-Agent: cursor/0.42.3` → `mcp_tool_called` with `upstream_client=cursor`, `tool_name=search_docs`
- [x] `initialize` with `DNT: 1` header → no analytics line, init still succeeds
- [x] `tools/call` with `X-Docfork-Telemetry: 0` → no analytics line, call still succeeds
- [x] `npm run typecheck` clean
- [x] `npm run lint:check` clean
- [x] `npm run build` clean

## Follow-ups (not in this PR)

- Backend: add `mcp_initialize` to the `/v1/telemetry` allowlist with the richer property set; expand `mcp_tool_called` allowlist to include `duration_ms`, `ok`, `error_kind`, `client_name` once those become useful.
- README: add a "Privacy & telemetry" section mirroring `packages/dgrep`. Same payload table + opt-out instructions.