### PR TITLE
fix(mcp): serve RFC 9728 path-aware OAuth discovery metadata

### DIFF
--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -36,17 +36,39 @@ function isWellKnownMcpConfigPath(pathname: string): boolean {
 
 function isWellKnownOauthProtectedResourcePath(pathname: string): boolean {
   const normalized = normalizePathname(pathname);
+  const segment = "/.well-known/oauth-protected-resource";
   return (
-    normalized === "/.well-known/oauth-protected-resource" ||
-    normalized.endsWith("/.well-known/oauth-protected-resource")
+    normalized === segment ||
+    // path-insertion form: /mcp/.well-known/oauth-protected-resource
+    normalized.endsWith(segment) ||
+    // rfc 9728 path-aware form: /.well-known/oauth-protected-resource/mcp
+    normalized.startsWith(`${segment}/`)
   );
 }
 
 function isWellKnownOauthAuthorizationServerPath(pathname: string): boolean {
   const normalized = normalizePathname(pathname);
+  const segment = "/.well-known/oauth-authorization-server";
   return (
-    normalized === "/.well-known/oauth-authorization-server" ||
-    normalized.endsWith("/.well-known/oauth-authorization-server")
+    normalized === segment ||
+    // path-insertion form: /mcp/.well-known/oauth-authorization-server
+    normalized.endsWith(segment) ||
+    // rfc 8414 path-aware form: /.well-known/oauth-authorization-server/mcp
+    normalized.startsWith(`${segment}/`)
+  );
+}
+
+/**
+ * well-known discovery paths must win over the /mcp endpoint matcher: the
+ * rfc 9728 form (/.well-known/oauth-protected-resource/mcp) ends with "/mcp",
+ * so isMcpEndpointPath would otherwise swallow it into the transport handler
+ * (→ 406/401 instead of metadata json).
+ */
+function isWellKnownDiscoveryPath(pathname: string): boolean {
+  return (
+    isWellKnownMcpConfigPath(pathname) ||
+    isWellKnownOauthProtectedResourcePath(pathname) ||
+    isWellKnownOauthAuthorizationServerPath(pathname)
   );
 }
 
@@ -211,7 +233,13 @@ export async function startHttpServer(
     }
 
     try {
-      if (isMcpEndpointPath(pathname) || isMcpOauthEndpointPath(pathname)) {
+      // discovery paths win over the /mcp matcher: the rfc 9728 path-aware form
+      // (/.well-known/oauth-protected-resource/mcp) ends with "/mcp" and would
+      // otherwise be swallowed into the transport handler (→ 406/401).
+      if (
+        !isWellKnownDiscoveryPath(pathname) &&
+        (isMcpEndpointPath(pathname) || isMcpOauthEndpointPath(pathname))
+      ) {
         // /mcp stays anonymous, /mcp/oauth requires auth
         const requireAuth = isMcpOauthEndpointPath(pathname);
         let authConfig: DocforkAuthConfig;


### PR DESCRIPTION
## Why

MCP clients implementing the 2025-11-25 authorization spec discover the authorization server via OAuth 2.0 Protected Resource Metadata (RFC 9728). When the MCP endpoint lives at a sub-path (`/mcp`), clients **must** try the path-aware well-known URI first, then fall back to the root:

1. `GET /.well-known/oauth-protected-resource/mcp`
2. `GET /.well-known/oauth-protected-resource`

We only served metadata at the root and the path-insertion form (`/mcp/.well-known/...`). The canonical path-aware URI ends with `/mcp`, so `isMcpEndpointPath()` matched it first and routed it into the streamable-HTTP transport handler. On a `GET` without an `Accept: text/event-stream` header that returns **406 Not Acceptable** instead of the metadata JSON.

Lenient clients fall back to the root URI and still authenticate; strict clients that honor the spec ordering and don't fall back fail authorization-server discovery outright.

Observed in production logs as a steady stream of:

```
GET 406  /.well-known/oauth-protected-resource/mcp
GET 406  /.well-known/oauth-authorization-server/mcp
```

## What

- `isWellKnownOauthProtectedResourcePath` / `isWellKnownOauthAuthorizationServerPath` now also match the path-aware form (`/.well-known/<metadata>/…`) in addition to the exact root and path-insertion suffix forms.
- New `isWellKnownDiscoveryPath` helper; the dispatcher checks it **before** the `/mcp` endpoint matcher so discovery paths ending in `/mcp` are no longer shadowed.

## Discovery routing after the fix

| Path | Before | After |
| --- | --- | --- |
| `/.well-known/oauth-protected-resource/mcp` | 406 (transport) | protected-resource metadata |
| `/.well-known/oauth-authorization-server/mcp` | 406 (transport) | authz-server metadata |
| `/.well-known/oauth-protected-resource` (root) | 200 | 200 (unchanged) |
| `/mcp/.well-known/oauth-protected-resource` | 200 | 200 (unchanged) |
| `/mcp` | transport | transport (unchanged) |
| `/mcp/oauth` | auth gate | auth gate (unchanged) |

## Test plan

- `pnpm typecheck` + `pnpm lint:check` pass.
- Routing simulated against all observed paths (table above).
- After deploy, verify live:
  ```
  curl -s https://mcp.docfork.com/.well-known/oauth-protected-resource/mcp | jq .resource
  ```
  expect the metadata JSON (was 406).

