### PR TITLE
chore(mcp): force docfork release to 2.2.3

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docfork",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Up-to-date code documentation for AI agents.",
   "mcpName": "io.github.docfork/docfork",
   "type": "module",


### PR DESCRIPTION
## Why

release-please has been stuck proposing a **2.2.2 → 0.0.1 downgrade** for the `docfork` (packages/mcp) component on every run (see the closed/reopened release PRs and the failed "Release Please" action).

Root cause: the empty commit `c8626af` (#146) carries an **unscoped** `Release-As: 0.0.1` footer. It was intended to pin the **sdk**'s first release, but as an empty commit it applied to every component with an open release window. It was consumed for sdk (`sdk-v0.0.1` tagged) but never for docfork/mcp, so it keeps winning as the only `Release-As` in mcp's unreleased range.

## What

A single commit touching `packages/mcp/package.json` with footer `Release-As: 2.2.3`. release-please honors the **last** `Release-As` in range, and the `packages/mcp` file touch **scopes** it to the docfork component so it can't leak to sdk/dgrep. 2.2.3 is the natural next version — it folds in the merged `fix:` for RFC 9728 path-aware discovery.

## Effect

Once merged and the regenerated release PR is merged, `docfork-v2.2.3` is cut, the tag advances past `c8626af`, and the `0.0.1` directive is permanently consumed.

## Test plan

- Merge this (squash, preserving the `Release-As:` footer).
- release-please regenerates a clean release PR titled *release docfork 2.2.3*.
- Confirm the regenerated PR sets manifest/package.json/server.json/gemini-extension.json to 2.2.3 (not 0.0.1).