### PR TITLE
chore: pin release-please last-release-sha to suppress dgrep 0.0.1 leak

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "last-release-sha": "36ebfd9e225561197603142978fc56ef54b0c959",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": true,


### PR DESCRIPTION
## Why

The empty commit `c8626af` (`Release-As: 0.0.1`, #146) sits *after* the `dgrep-v0.2.1` tag, so release-please keeps proposing a **dgrep 0.2.1 → 0.0.1 downgrade** (PR #158). mcp escaped once `docfork-v2.2.3` advanced its tag past `c8626af`; dgrep has no release since 0.2.1, so the unscoped directive still applies to it. Forcing a dgrep version isn't an option — dgrep is unpublished and `release.yml` would attempt an npm publish on any `dgrep-v*` tag.

## What

Set `last-release-sha` to the `docfork-v2.2.3` release commit (`36ebfd9e`, current main HEAD) so release-please treats everything up to here as released for **all** components, excluding `c8626af` from every range. No dgrep commits exist between `dgrep-v0.2.1` and this sha, so nothing is dropped.

## Effect

- #158 (`release dgrep 0.0.1`) auto-closes; dgrep stays 0.2.1, no publish.
- mcp/sdk unaffected (already past the baseline).

## Cleanup

Remove this pin once dgrep cuts its first real release — its tag will then sit past `c8626af` on its own.