### PR TITLE
fix(mcp): validate token audience (aud) in jwt verification

### DIFF
--- a/packages/mcp/src/lib/jwt.ts
+++ b/packages/mcp/src/lib/jwt.ts
@@ -57,8 +57,10 @@ const AUTH_DOMAIN = "login.docfork.com";
 const JWKS_URL = `https://${AUTH_DOMAIN}/oauth2/jwks`;
 const ISSUER = `https://${AUTH_DOMAIN}`;
 
+// canonical resource-server uri; tokens whose `aud` differs are rejected.
+const AUDIENCE = "https://mcp.docfork.com";
+
 // optional validation parameters (undefined = skip these checks)
-const AUDIENCE = undefined;
 const ALGORITHMS = undefined;
 const PUBLIC_KEY_PEM = undefined;
 


### PR DESCRIPTION
Resolves DOC-369.

## Why

2025-11-25 MCP auth spec (resource server): MUST only accept tokens issued for itself (token `aud` matches the canonical RS URI), and reject tokens issued for other audiences. `packages/mcp/src/lib/jwt.ts` left `AUDIENCE = undefined`, so `jwtVerify` skipped the audience check entirely — a token minted for a different resource would pass.

## What

Set `AUDIENCE` to the canonical RS URI `https://mcp.docfork.com` (matching the `resource` advertised in protected-resource metadata). `jwtVerify` now rejects tokens whose `aud` differs. One-line change; verification only runs on the OAuth-protected route.

## ⚠️ Merge prerequisite — DO NOT MERGE until confirmed

This **will 401 every OAuth client** unless the authorization server actually issues `aud = https://mcp.docfork.com`. Per the WorkOS MCP guide, that requires a **Resource Indicator** set to exactly `https://mcp.docfork.com` in the WorkOS dashboard (Connect → Resource Indicators). If no Resource Indicator is configured, WorkOS issues a default env-unique `aud` and ignores the `resource` param — and this change would reject all tokens on the next auto-deploy.

Before merging:
- [ ] Confirm the Resource Indicator `https://mcp.docfork.com` is configured in WorkOS.
- [ ] Decode a live access token and confirm `aud === "https://mcp.docfork.com"`.

## Test plan (acceptance)

- [ ] Token with wrong `aud` → 401.
- [ ] Token with correct `aud` → accepted.
- [ ] Inspector against `https://mcp.docfork.com/mcp` still authenticates with a valid token after deploy.

Note: the deploy repo auto-deploys `docfork@latest` on image rebuild, so this ships to prod once released. Hold release until the prerequisite is verified.