### PR TITLE
fix(mcp): return 403 on disallowed Origin header

### DIFF
--- a/packages/mcp/src/transport.ts
+++ b/packages/mcp/src/transport.ts
@@ -128,6 +128,41 @@ async function parseRequestBody(req: IncomingMessage): Promise<any> {
 }
 
 /**
+ * validate the Origin header for dns-rebinding protection (mcp 2025-11-25).
+ * no Origin (cli clients) is allowed; only browser-set origins are policed.
+ */
+function isOriginAllowed(origin: string | undefined): boolean {
+  // cli clients (claude code, cursor, inspector proxy) send no Origin
+  if (!origin || origin === "null") return true;
+
+  const configured = (process.env.DOCFORK_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+  // escape hatch: disable the check entirely
+  if (configured.includes("*")) return true;
+
+  let hostname: string;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    // malformed Origin is invalid
+    return false;
+  }
+
+  // localhost / loopback (any scheme, any port) for inspector + local dev
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+    return true;
+  }
+  // docfork's own surfaces
+  if (hostname === "docfork.com" || hostname.endsWith(".docfork.com")) {
+    return true;
+  }
+  // exact-match env allowlist
+  return configured.includes(origin);
+}
+
+/**
  * Send JSON-RPC error response
  */
 function sendJsonError(
@@ -262,6 +297,13 @@ export async function startHttpServer(
           };
         } catch (error: any) {
           sendJsonError(res, 400, -32602, error.message || "Invalid configuration");
+          return;
+        }
+
+        // dns-rebinding protection: reject browser-set origins not on the allowlist
+        const origin = typeof req.headers.origin === "string" ? req.headers.origin : undefined;
+        if (!isOriginAllowed(origin)) {
+          sendJsonError(res, 403, -32001, "Origin not allowed");
           return;
         }
 


### PR DESCRIPTION
## Why
The streamable-HTTP transport in `packages/mcp/src/transport.ts` set `Access-Control-Allow-Origin: *` but never inspected the `Origin` header, so it neither complied with the MCP 2025-11-25 requirement to return `403 Forbidden` on an invalid `Origin` nor offered DNS-rebinding protection. DNS rebinding lets a malicious web page script `fetch()` calls to an MCP server (most dangerous for a locally-bound server binary, where a visited site can reach the user's `localhost` MCP process and invoke tools on their behalf). The `Origin` header is the browser's tamper-proof signal of who initiated a request; validating it closes that gap. Exposure on the public anonymous `mcp.docfork.com` endpoint is low (no ambient credentials to ride on), but the shipped local-transport case is real, and the fix is small and self-contained.

## What changed
- add `isOriginAllowed()` helper: allow no-Origin/`null` (cli clients), localhost/loopback, `docfork.com`/`*.docfork.com`, and an exact-match `DOCFORK_ALLOWED_ORIGINS` env list; `*` disables the check
- enforce in the `/mcp` + `/mcp/oauth` request branch, returning `403 -32001 "Origin not allowed"` before auth

## Context
- Linear: DOC-370 (sub-issue of DOC-368, MCP OAuth + deploy hardening)
- MCP 2025-11-25 transports spec (Origin validation)
- Non-goals: does not wire the SDK's `enableDnsRebindingProtection`; the router runs ahead of `StreamableHTTPServerTransport` and the in-router check also guards `/mcp/oauth`. CORS `Access-Control-Allow-Origin: *` is unchanged — the 403 is the enforcement layer.

## Impact / risk
- new optional env var `DOCFORK_ALLOWED_ORIGINS` (comma-separated exact origins; `*` to disable). Prod needs no change — `mcp.docfork.com` is in the baked-in allowlist.
- behavior change: browser requests carrying a disallowed `Origin` now get 403 instead of being served. CLI clients (no `Origin`) are unaffected, so Claude Code / Cursor / Inspector are not impacted.

## Test plan
- [ ] `MCP_TRANSPORT=streamable-http PORT=8765 node dist/index.js`; POST an initialize body with `Origin: https://evil.example` → **403** `{"error":{"code":-32001,"message":"Origin not allowed"}}`
- [ ] same POST with no `Origin`, with `Origin: http://localhost:6274`, and with `Origin: https://mcp.docfork.com` → reaches transport (200 with `Accept: application/json, text/event-stream`)
- [ ] malformed `Origin: not-a-url` → 403; `OPTIONS` preflight → 200
- [ ] `DOCFORK_ALLOWED_ORIGINS=https://foo.test` allows that origin (unlisted → 403); `DOCFORK_ALLOWED_ORIGINS=*` allows any origin