### PR TITLE
feat(dgrep): typed agent registry + OAuth-first setup + 6 editors

### DIFF
--- a/packages/dgrep/package.json
+++ b/packages/dgrep/package.json
@@ -42,5 +42,8 @@
     "url": "https://github.com/docfork/docfork",
     "directory": "packages/dgrep"
   },
-  "homepage": "https://github.com/docfork/docfork#readme"
+  "homepage": "https://github.com/docfork/docfork#readme",
+  "dependencies": {
+    "smol-toml": "^1.6.1"
+  }
 }

--- a/packages/dgrep/src/bin.ts
+++ b/packages/dgrep/src/bin.ts
@@ -6,6 +6,7 @@ import { DgrepError } from "./lib/errors.js";
 import { loadAccent } from "./lib/theme.js";
 import { VERSION } from "./lib/version.js";
 import { loadConfig } from "./lib/config.js";
+import { AGENTS } from "./lib/agents.js";
 import { ensureInstallId, isTelemetryEnabled, showFirstRunNotice } from "./lib/telemetry/optout.js";
 import { captureCommandExecuted, captureError, captureInstall } from "./lib/telemetry/events.js";
 import { isCI } from "./lib/telemetry/transport.js";
@@ -150,18 +151,17 @@ function buildCli() {
       "setup",
       "Setup IDE agent integrations",
       (yargs) => {
-        return yargs
-          .option("cursor", { type: "boolean", describe: "Setup Cursor only" })
-          .option("claude", { type: "boolean", describe: "Setup Claude Code only" })
-          .option("opencode", { type: "boolean", describe: "Setup OpenCode only" })
-          .option("all", { type: "boolean", describe: "Setup all detected agents" });
+        return yargs.option("agent", {
+          type: "string",
+          array: true,
+          choices: Object.keys(AGENTS),
+          describe: "Limit setup to one or more agents (default: all detected)",
+        });
       },
       async (argv) => {
         const { setup } = await import("./commands/setup.js");
         await setup({
-          cursor: argv.cursor as boolean | undefined,
-          claude: argv.claude as boolean | undefined,
-          opencode: argv.opencode as boolean | undefined,
+          agents: argv.agent as string[] | undefined,
           yes: argv.yes as boolean | undefined,
           apiKey: argv["api-key"] as string | undefined,
         });

--- a/packages/dgrep/src/bin.ts
+++ b/packages/dgrep/src/bin.ts
@@ -163,7 +163,6 @@ function buildCli() {
         await setup({
           agents: argv.agent as string[] | undefined,
           yes: argv.yes as boolean | undefined,
-          apiKey: argv["api-key"] as string | undefined,
         });
       }
     )

--- a/packages/dgrep/src/commands/doctor.ts
+++ b/packages/dgrep/src/commands/doctor.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { constants } from "node:fs";
 import { loadConfig, configPath } from "../lib/config.js";
 import { findProjectRoot, loadProjectConfig } from "../lib/project-config.js";
-import { detectAgents } from "../lib/agents.js";
+import { agentDisplayList, detectAgents } from "../lib/agents.js";
 import { searchDocs } from "../lib/api-client.js";
 
 export interface DoctorOptions {
@@ -135,7 +135,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<void> {
     checks.push({
       name: "Agents",
       status: "warn",
-      message: "None detected (Cursor, Claude Code, OpenCode)",
+      message: `None detected (${agentDisplayList()})`,
     });
   }
 

--- a/packages/dgrep/src/commands/setup.ts
+++ b/packages/dgrep/src/commands/setup.ts
@@ -1,14 +1,12 @@
 import { accent } from "../lib/theme.js";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { resolveAuth } from "../lib/auth.js";
 import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
 import type { DetectedAgent } from "../lib/agents.js";
 
 export interface SetupOptions {
   agents?: string[];
   yes?: boolean;
-  apiKey?: string;
   cwd?: string;
 }
 
@@ -16,17 +14,6 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
 
   p.intro(accent().bg(pc.black(" dgrep setup ")));
-
-  const auth = await resolveAuth(options.apiKey);
-  const apiKey = auth.apiKey;
-
-  if (!apiKey) {
-    p.log.error(
-      `No API key found. Run ${accent().fg("dgrep login")} or ${accent().fg("npx dgrep")} first.`
-    );
-    process.exitCode = 1;
-    return;
-  }
 
   // detect agents
   const allAgents = await detectAgents(cwd);
@@ -58,7 +45,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
     if (!options.yes) {
       if (agent.name === "claude-code") {
         p.log.info(
-          `Or run manually:\n  ${accent().fg(`claude mcp add --transport http docfork https://mcp.docfork.com/mcp --header "DOCFORK_API_KEY: ${apiKey}"`)}`
+          `Or run manually:\n  ${accent().fg("claude mcp add --transport http docfork https://mcp.docfork.com/mcp")}`
         );
       }
 
@@ -68,9 +55,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
       if (!writeConfig || p.isCancel(writeConfig)) continue;
     }
 
-    await writeMcpConfigForAgent(agent, apiKey);
+    await writeMcpConfigForAgent(agent);
     p.log.success(`${agent.displayName}: ${pc.dim(agent.configPath)} updated`);
   }
 
-  p.outro("Done. Your IDE agents can now use Docfork.");
+  p.outro("Done. Sign in to Docfork in your IDE on first use.");
 }

--- a/packages/dgrep/src/commands/setup.ts
+++ b/packages/dgrep/src/commands/setup.ts
@@ -1,7 +1,7 @@
 import { accent } from "../lib/theme.js";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
+import { AGENTS, agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
 import type { DetectedAgent } from "../lib/agents.js";
 
 export interface SetupOptions {
@@ -57,6 +57,9 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
 
     await writeMcpConfigForAgent(agent);
     p.log.success(`${agent.displayName}: ${pc.dim(agent.configPath)} updated`);
+
+    const note = AGENTS[agent.name].postWriteNote;
+    if (note) p.log.info(note);
   }
 
   p.outro("Done. Sign in to Docfork in your IDE on first use.");

--- a/packages/dgrep/src/commands/setup.ts
+++ b/packages/dgrep/src/commands/setup.ts
@@ -2,9 +2,8 @@ import { accent } from "../lib/theme.js";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { resolveAuth } from "../lib/auth.js";
-import { detectAgents } from "../lib/agents.js";
+import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
 import type { DetectedAgent } from "../lib/agents.js";
-import { writeMcpConfigForAgent } from "../lib/agents.js";
 
 export interface SetupOptions {
   cursor?: boolean;
@@ -56,7 +55,7 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   }
 
   if (agents.length === 0) {
-    p.log.info("No IDE agents detected (Cursor, Claude Code, OpenCode).");
+    p.log.info(`No IDE agents detected (${agentDisplayList()}).`);
     p.outro("Nothing to set up.");
     return;
   }

--- a/packages/dgrep/src/commands/setup.ts
+++ b/packages/dgrep/src/commands/setup.ts
@@ -6,9 +6,7 @@ import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/a
 import type { DetectedAgent } from "../lib/agents.js";
 
 export interface SetupOptions {
-  cursor?: boolean;
-  claude?: boolean;
-  opencode?: boolean;
+  agents?: string[];
   yes?: boolean;
   apiKey?: string;
   cwd?: string;
@@ -33,17 +31,11 @@ export async function setup(options: SetupOptions = {}): Promise<void> {
   // detect agents
   const allAgents = await detectAgents(cwd);
 
-  // filter by flags if specified
-  const filterFlags = options.cursor || options.claude || options.opencode;
+  // filter to requested subset if --agent specified
   let agents: DetectedAgent[];
-
-  if (filterFlags) {
-    agents = allAgents.filter((a) => {
-      if (options.cursor && a.name === "cursor") return true;
-      if (options.claude && a.name === "claude-code") return true;
-      if (options.opencode && a.name === "opencode") return true;
-      return false;
-    });
+  if (options.agents && options.agents.length > 0) {
+    const requested = new Set(options.agents);
+    agents = allAgents.filter((a) => requested.has(a.name));
 
     if (agents.length === 0) {
       p.log.warning("Requested agents not detected in this project.");

--- a/packages/dgrep/src/commands/status.ts
+++ b/packages/dgrep/src/commands/status.ts
@@ -2,17 +2,11 @@ import { accent } from "../lib/theme.js";
 import pc from "picocolors";
 import { loadConfig, configPath } from "../lib/config.js";
 import { findProjectRoot, loadProjectConfig } from "../lib/project-config.js";
-import { detectAgents } from "../lib/agents.js";
+import { AGENTS, detectAgents } from "../lib/agents.js";
+import type { AgentType } from "../lib/agents.js";
 import { detectProjectDeps } from "../lib/detect-deps.js";
 
 const VERSION = "0.1.0";
-
-const KNOWN_AGENTS = ["cursor", "claude-code", "opencode"] as const;
-const AGENT_DISPLAY: Record<string, string> = {
-  cursor: "Cursor",
-  "claude-code": "Claude Code",
-  opencode: "OpenCode",
-};
 
 export interface StatusOptions {
   json?: boolean;
@@ -57,7 +51,7 @@ export async function status(options: StatusOptions = {}): Promise<void> {
         },
         libraries: libs,
         librarySource: libs.length > 0 ? "project" : detected.deps.length > 0 ? "detected" : "none",
-        agents: KNOWN_AGENTS.map((name) => ({
+        agents: (Object.keys(AGENTS) as AgentType[]).map((name) => ({
           name,
           detected: detectedNames.has(name),
         })),
@@ -142,9 +136,9 @@ export async function status(options: StatusOptions = {}): Promise<void> {
   console.log("");
 
   // Agents
-  const agentParts = KNOWN_AGENTS.map((name) => {
-    const display = AGENT_DISPLAY[name];
-    return detectedNames.has(name) ? `${display} ${pc.green("✓")}` : `${display} ${pc.red("✗")}`;
+  const agentParts = Object.values(AGENTS).map((agent) => {
+    const mark = detectedNames.has(agent.name) ? pc.green("✓") : pc.red("✗");
+    return `${agent.displayName} ${mark}`;
   });
   console.log(`  ${label("Agents")}${agentParts.join("  ")}`);
 

--- a/packages/dgrep/src/commands/wizard.ts
+++ b/packages/dgrep/src/commands/wizard.ts
@@ -3,7 +3,7 @@ import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { resolveAuth } from "../lib/auth.js";
 import { saveConfig } from "../lib/config.js";
-import { detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
+import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
 import { provisionKey } from "../lib/api-client.js";
 
 export interface WizardOptions {
@@ -25,7 +25,7 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
   if (agents.length > 0) {
     p.log.success(`Detected: ${agents.map((a) => accent().fg(a.displayName)).join(", ")}`);
   } else {
-    p.log.info("No IDE agents detected (Cursor, Claude Code, OpenCode).");
+    p.log.info(`No IDE agents detected (${agentDisplayList()}).`);
   }
 
   // -- Resolve or provision credentials -----------------------------------

--- a/packages/dgrep/src/commands/wizard.ts
+++ b/packages/dgrep/src/commands/wizard.ts
@@ -1,14 +1,10 @@
 import { accent } from "../lib/theme.js";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { resolveAuth } from "../lib/auth.js";
-import { saveConfig } from "../lib/config.js";
 import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
-import { provisionKey } from "../lib/api-client.js";
 
 export interface WizardOptions {
   yes?: boolean;
-  apiKey?: string;
   cwd?: string;
 }
 
@@ -28,35 +24,6 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
     p.log.info(`No IDE agents detected (${agentDisplayList()}).`);
   }
 
-  // -- Resolve or provision credentials -----------------------------------
-
-  const auth = await resolveAuth(options.apiKey);
-  let apiKey = auth.apiKey;
-
-  if (apiKey) {
-    p.log.success("API key found.");
-  } else {
-    p.log.step("Provisioning API key (no login required)...");
-
-    const provisionSpinner = p.spinner();
-    provisionSpinner.start("Provisioning...");
-
-    const result = await provisionKey();
-    apiKey = result.api_key;
-
-    if (!apiKey) {
-      provisionSpinner.stop("Failed.");
-      throw new Error("Provision response missing API key. Try again or run `dgrep login`.");
-    }
-
-    await saveConfig({
-      apiKey,
-      expiresAt: result.expires_at,
-    });
-
-    provisionSpinner.stop("API key provisioned.");
-  }
-
   // -- Write MCP configs -----------------------------------
 
   if (agents.length > 0) {
@@ -65,7 +32,7 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
         // Show manual CLI alternative for Claude Code
         if (agent.name === "claude-code") {
           p.log.info(
-            `Or run manually:\n  ${accent().fg(`claude mcp add --transport http docfork https://mcp.docfork.com/mcp --header "DOCFORK_API_KEY: ${apiKey}"`)}`
+            `Or run manually:\n  ${accent().fg("claude mcp add --transport http docfork https://mcp.docfork.com/mcp")}`
           );
         }
 
@@ -75,7 +42,7 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
         if (!writeConfig || p.isCancel(writeConfig)) continue;
       }
 
-      await writeMcpConfigForAgent(agent, apiKey!);
+      await writeMcpConfigForAgent(agent);
       p.log.success(`${agent.displayName}: ${pc.dim(agent.configPath)} updated`);
     }
   }
@@ -85,7 +52,7 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
   p.log.message("");
   p.log.step("Next steps:");
   if (agents.length > 0) {
-    p.log.info(`Your IDE agents can now use Docfork. Try searching in ${agents[0].displayName}!`);
+    p.log.info(`Sign in to Docfork in ${agents[0].displayName} on first use.`);
   }
   p.log.info(`Run ${accent().fg("dgrep init")} to track your project's libraries.`);
   p.log.info(`Run ${accent().fg("dgrep login")} to link your account (1K/mo free).`);

--- a/packages/dgrep/src/commands/wizard.ts
+++ b/packages/dgrep/src/commands/wizard.ts
@@ -1,7 +1,7 @@
 import { accent } from "../lib/theme.js";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
+import { AGENTS, agentDisplayList, detectAgents, writeMcpConfigForAgent } from "../lib/agents.js";
 
 export interface WizardOptions {
   yes?: boolean;
@@ -44,6 +44,9 @@ export async function wizard(options: WizardOptions = {}): Promise<void> {
 
       await writeMcpConfigForAgent(agent);
       p.log.success(`${agent.displayName}: ${pc.dim(agent.configPath)} updated`);
+
+      const note = AGENTS[agent.name].postWriteNote;
+      if (note) p.log.info(note);
     }
   }
 

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -18,7 +18,8 @@ export type AgentType =
   | "vscode"
   | "windsurf"
   | "amp"
-  | "factory";
+  | "factory"
+  | "zed";
 
 // path is relative to project root for project-dir, relative to homedir for user-dir;
 // binary kind probes for an executable on $PATH (cross-platform)
@@ -59,6 +60,13 @@ export interface AgentConfig {
   // optional one-line hint shown after a successful write
   postWriteNote?: string;
 }
+
+// -- Platform-specific paths -----------------------------------
+
+// zed stores its settings under different home-relative paths per OS;
+// resolved once at module load
+const ZED_DIR =
+  process.platform === "darwin" ? "Library/Application Support/Zed" : ".config/zed";
 
 // -- Registry -----------------------------------
 
@@ -192,6 +200,24 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
       kind: "shell",
       bin: "droid",
       args: ["mcp", "add", "docfork", "https://mcp.docfork.com/mcp", "--type", "http"],
+    },
+  },
+  zed: {
+    name: "zed",
+    displayName: "Zed",
+    probe: { kind: "user-dir", path: ZED_DIR },
+    writer: {
+      kind: "file",
+      configPath: `${ZED_DIR}/settings.json`,
+      // url-only (no Authorization header) triggers Zed's standard MCP OAuth prompt per their docs
+      buildServerEntry: () => ({
+        url: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const contextServers = (existing.context_servers ?? {}) as Record<string, unknown>;
+        contextServers["docfork"] = entry;
+        return { ...existing, context_servers: contextServers };
+      },
     },
   },
 };

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -2,35 +2,38 @@ import { access, readFile, writeFile, copyFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { constants } from "node:fs";
 
+// -- Types -----------------------------------
+
+export type AgentType = "cursor" | "claude-code" | "opencode";
+
+// probe kinds expand as new agents land (user-dir, binary, etc.)
+export type ProbeSpec = { kind: "project-dir"; path: string };
+
 export interface DetectedAgent {
-  name: string;
+  name: AgentType;
   displayName: string;
   configPath: string;
 }
 
-export interface AgentDefinition {
-  name: string;
+export interface AgentConfig {
+  name: AgentType;
   displayName: string;
-  /** Directory to probe for detection (relative to project root) */
-  probeDir: string;
-  /** Config file path (relative to project root) */
-  configPath: string;
-  /** Build the MCP server entry for this agent */
+  probe: ProbeSpec;
+  configPath: string; // relative to project root for project-dir agents
   buildServerEntry: (apiKey: string) => Record<string, unknown>;
-  /** Read existing config, merge docfork server, return updated config */
   mergeConfig: (
     existing: Record<string, unknown>,
     serverEntry: Record<string, unknown>
   ) => Record<string, unknown>;
 }
 
-// -- Agent definitions -----------------------------------
+// -- Registry -----------------------------------
 
-const AGENTS: AgentDefinition[] = [
-  {
+export const AGENTS: Record<AgentType, AgentConfig> = {
+  cursor: {
     name: "cursor",
     displayName: "Cursor",
-    probeDir: ".cursor",
+    probe: { kind: "project-dir", path: ".cursor" },
     configPath: ".cursor/mcp.json",
     buildServerEntry: (apiKey) => ({
       url: "https://mcp.docfork.com/mcp",
@@ -42,10 +45,10 @@ const AGENTS: AgentDefinition[] = [
       return { ...existing, mcpServers };
     },
   },
-  {
+  "claude-code": {
     name: "claude-code",
     displayName: "Claude Code",
-    probeDir: ".claude",
+    probe: { kind: "project-dir", path: ".claude" },
     configPath: ".mcp.json",
     buildServerEntry: (apiKey) => ({
       type: "http",
@@ -58,10 +61,10 @@ const AGENTS: AgentDefinition[] = [
       return { ...existing, mcpServers };
     },
   },
-  {
+  opencode: {
     name: "opencode",
     displayName: "OpenCode",
-    probeDir: ".opencode",
+    probe: { kind: "project-dir", path: ".opencode" },
     configPath: "opencode.json",
     buildServerEntry: (apiKey) => ({
       type: "remote",
@@ -75,7 +78,7 @@ const AGENTS: AgentDefinition[] = [
       return { ...existing, mcp };
     },
   },
-];
+};
 
 // -- Detection -----------------------------------
 
@@ -83,49 +86,49 @@ export async function detectAgents(cwd?: string): Promise<DetectedAgent[]> {
   const dir = cwd ?? process.cwd();
   const detected: DetectedAgent[] = [];
 
-  const checks = AGENTS.map(async (agent) => {
-    try {
-      await access(join(dir, agent.probeDir), constants.F_OK);
-      detected.push({
-        name: agent.name,
-        displayName: agent.displayName,
-        configPath: join(dir, agent.configPath),
-      });
-    } catch {
-      // not found
-    }
-  });
+  await Promise.all(
+    Object.values(AGENTS).map(async (agent) => {
+      try {
+        await access(join(dir, agent.probe.path), constants.F_OK);
+        detected.push({
+          name: agent.name,
+          displayName: agent.displayName,
+          configPath: join(dir, agent.configPath),
+        });
+      } catch {
+        // probe target missing
+      }
+    })
+  );
 
-  await Promise.all(checks);
   return detected.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function getAgentDefinition(name: string): AgentDefinition | undefined {
-  return AGENTS.find((a) => a.name === name);
+export function getAgentDefinition(name: string): AgentConfig | undefined {
+  return (AGENTS as Record<string, AgentConfig | undefined>)[name];
 }
 
 // -- Config writing -----------------------------------
 
-export async function writeMcpConfigForAgent(agent: DetectedAgent, apiKey: string): Promise<void> {
-  const def = getAgentDefinition(agent.name);
-  if (!def) return;
-
+export async function writeMcpConfigForAgent(
+  agent: DetectedAgent,
+  apiKey: string
+): Promise<void> {
+  const def = AGENTS[agent.name];
   const serverEntry = def.buildServerEntry(apiKey);
 
-  // Read existing config
+  // read existing config; back it up before modifying
   let existing: Record<string, unknown> = {};
   try {
     const raw = await readFile(agent.configPath, "utf-8");
     existing = JSON.parse(raw) as Record<string, unknown>;
-    // Backup before modifying
     await copyFile(agent.configPath, agent.configPath + ".bak");
   } catch {
-    // File doesn't exist, start fresh
+    // file doesn't exist, start fresh
   }
 
   const updated = def.mergeConfig(existing, serverEntry);
 
-  // Ensure parent directory exists
   await mkdir(dirname(agent.configPath), { recursive: true });
   await writeFile(agent.configPath, JSON.stringify(updated, null, 2) + "\n");
 }

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -6,7 +6,13 @@ import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 
 // -- Types -----------------------------------
 
-export type AgentType = "cursor" | "claude-code" | "opencode" | "codex" | "vscode";
+export type AgentType =
+  | "cursor"
+  | "claude-code"
+  | "opencode"
+  | "codex"
+  | "vscode"
+  | "windsurf";
 
 // path is relative to project root for project-dir, relative to homedir for user-dir
 export type ProbeSpec =
@@ -116,6 +122,21 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
       const servers = (existing.servers ?? {}) as Record<string, unknown>;
       servers["docfork"] = entry;
       return { ...existing, servers };
+    },
+  },
+  windsurf: {
+    name: "windsurf",
+    displayName: "Windsurf",
+    probe: { kind: "user-dir", path: ".codeium/windsurf" },
+    configPath: ".codeium/windsurf/mcp_config.json",
+    // windsurf uses serverUrl (not url); docs say it supports OAuth for each transport type
+    buildServerEntry: () => ({
+      serverUrl: "https://mcp.docfork.com/mcp",
+    }),
+    mergeConfig: (existing, entry) => {
+      const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+      mcpServers["docfork"] = entry;
+      return { ...existing, mcpServers };
     },
   },
 };

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -20,7 +20,8 @@ export interface AgentConfig {
   displayName: string;
   probe: ProbeSpec;
   configPath: string; // relative to project root for project-dir agents
-  buildServerEntry: (apiKey: string) => Record<string, unknown>;
+  // url-only stanza; the IDE handles MCP-spec OAuth on first connect
+  buildServerEntry: () => Record<string, unknown>;
   mergeConfig: (
     existing: Record<string, unknown>,
     serverEntry: Record<string, unknown>
@@ -35,9 +36,8 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
     displayName: "Cursor",
     probe: { kind: "project-dir", path: ".cursor" },
     configPath: ".cursor/mcp.json",
-    buildServerEntry: (apiKey) => ({
+    buildServerEntry: () => ({
       url: "https://mcp.docfork.com/mcp",
-      headers: { DOCFORK_API_KEY: apiKey },
     }),
     mergeConfig: (existing, entry) => {
       const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
@@ -50,10 +50,9 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
     displayName: "Claude Code",
     probe: { kind: "project-dir", path: ".claude" },
     configPath: ".mcp.json",
-    buildServerEntry: (apiKey) => ({
+    buildServerEntry: () => ({
       type: "http",
       url: "https://mcp.docfork.com/mcp",
-      headers: { DOCFORK_API_KEY: apiKey },
     }),
     mergeConfig: (existing, entry) => {
       const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
@@ -66,10 +65,9 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
     displayName: "OpenCode",
     probe: { kind: "project-dir", path: ".opencode" },
     configPath: "opencode.json",
-    buildServerEntry: (apiKey) => ({
+    buildServerEntry: () => ({
       type: "remote",
       url: "https://mcp.docfork.com/mcp",
-      headers: { DOCFORK_API_KEY: apiKey },
       enabled: true,
     }),
     mergeConfig: (existing, entry) => {
@@ -117,12 +115,9 @@ export function agentDisplayList(): string {
 
 // -- Config writing -----------------------------------
 
-export async function writeMcpConfigForAgent(
-  agent: DetectedAgent,
-  apiKey: string
-): Promise<void> {
+export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void> {
   const def = AGENTS[agent.name];
-  const serverEntry = def.buildServerEntry(apiKey);
+  const serverEntry = def.buildServerEntry();
 
   // read existing config; back it up before modifying
   let existing: Record<string, unknown> = {};

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -65,8 +65,7 @@ export interface AgentConfig {
 
 // zed stores its settings under different home-relative paths per OS;
 // resolved once at module load
-const ZED_DIR =
-  process.platform === "darwin" ? "Library/Application Support/Zed" : ".config/zed";
+const ZED_DIR = process.platform === "darwin" ? "Library/Application Support/Zed" : ".config/zed";
 
 // -- Registry -----------------------------------
 

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -6,7 +6,7 @@ import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 
 // -- Types -----------------------------------
 
-export type AgentType = "cursor" | "claude-code" | "opencode" | "codex";
+export type AgentType = "cursor" | "claude-code" | "opencode" | "codex" | "vscode";
 
 // path is relative to project root for project-dir, relative to homedir for user-dir
 export type ProbeSpec =
@@ -101,6 +101,21 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
       const mcpServers = (existing.mcp_servers ?? {}) as Record<string, unknown>;
       mcpServers["docfork"] = entry;
       return { ...existing, mcp_servers: mcpServers };
+    },
+  },
+  vscode: {
+    name: "vscode",
+    displayName: "VS Code",
+    probe: { kind: "project-dir", path: ".vscode" },
+    configPath: ".vscode/mcp.json",
+    buildServerEntry: () => ({
+      type: "http",
+      url: "https://mcp.docfork.com/mcp",
+    }),
+    mergeConfig: (existing, entry) => {
+      const servers = (existing.servers ?? {}) as Record<string, unknown>;
+      servers["docfork"] = entry;
+      return { ...existing, servers };
     },
   },
 };

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -1,13 +1,19 @@
 import { access, readFile, writeFile, copyFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { constants } from "node:fs";
+import { homedir } from "node:os";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 
 // -- Types -----------------------------------
 
-export type AgentType = "cursor" | "claude-code" | "opencode";
+export type AgentType = "cursor" | "claude-code" | "opencode" | "codex";
 
-// probe kinds expand as new agents land (user-dir, binary, etc.)
-export type ProbeSpec = { kind: "project-dir"; path: string };
+// path is relative to project root for project-dir, relative to homedir for user-dir
+export type ProbeSpec =
+  | { kind: "project-dir"; path: string }
+  | { kind: "user-dir"; path: string };
+
+export type WriteFormat = "json" | "toml";
 
 export interface DetectedAgent {
   name: AgentType;
@@ -19,7 +25,12 @@ export interface AgentConfig {
   name: AgentType;
   displayName: string;
   probe: ProbeSpec;
-  configPath: string; // relative to project root for project-dir agents
+  // resolved against cwd (project-dir) or homedir (user-dir)
+  configPath: string;
+  // defaults to "json" when omitted
+  writeFormat?: WriteFormat;
+  // optional one-line hint shown after a successful write
+  postWriteNote?: string;
   // url-only stanza; the IDE handles MCP-spec OAuth on first connect
   buildServerEntry: () => Record<string, unknown>;
   mergeConfig: (
@@ -76,22 +87,44 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
       return { ...existing, mcp };
     },
   },
+  codex: {
+    name: "codex",
+    displayName: "OpenAI Codex",
+    probe: { kind: "user-dir", path: ".codex" },
+    configPath: ".codex/config.toml",
+    writeFormat: "toml",
+    postWriteNote: "Run `codex mcp login docfork` to complete OAuth.",
+    buildServerEntry: () => ({
+      url: "https://mcp.docfork.com/mcp",
+    }),
+    mergeConfig: (existing, entry) => {
+      const mcpServers = (existing.mcp_servers ?? {}) as Record<string, unknown>;
+      mcpServers["docfork"] = entry;
+      return { ...existing, mcp_servers: mcpServers };
+    },
+  },
 };
 
 // -- Detection -----------------------------------
 
-export async function detectAgents(cwd?: string): Promise<DetectedAgent[]> {
+function probeRoot(probe: ProbeSpec, cwd: string, home: string): string {
+  return probe.kind === "project-dir" ? cwd : home;
+}
+
+export async function detectAgents(cwd?: string, home?: string): Promise<DetectedAgent[]> {
   const dir = cwd ?? process.cwd();
+  const userHome = home ?? homedir();
   const detected: DetectedAgent[] = [];
 
   await Promise.all(
     Object.values(AGENTS).map(async (agent) => {
+      const root = probeRoot(agent.probe, dir, userHome);
       try {
-        await access(join(dir, agent.probe.path), constants.F_OK);
+        await access(join(root, agent.probe.path), constants.F_OK);
         detected.push({
           name: agent.name,
           displayName: agent.displayName,
-          configPath: join(dir, agent.configPath),
+          configPath: join(root, agent.configPath),
         });
       } catch {
         // probe target missing
@@ -118,12 +151,16 @@ export function agentDisplayList(): string {
 export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void> {
   const def = AGENTS[agent.name];
   const serverEntry = def.buildServerEntry();
+  const format = def.writeFormat ?? "json";
 
   // read existing config; back it up before modifying
   let existing: Record<string, unknown> = {};
   try {
     const raw = await readFile(agent.configPath, "utf-8");
-    existing = JSON.parse(raw) as Record<string, unknown>;
+    existing =
+      format === "toml"
+        ? (parseToml(raw) as Record<string, unknown>)
+        : (JSON.parse(raw) as Record<string, unknown>);
     await copyFile(agent.configPath, agent.configPath + ".bak");
   } catch {
     // file doesn't exist, start fresh
@@ -132,5 +169,7 @@ export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void
   const updated = def.mergeConfig(existing, serverEntry);
 
   await mkdir(dirname(agent.configPath), { recursive: true });
-  await writeFile(agent.configPath, JSON.stringify(updated, null, 2) + "\n");
+  const serialized =
+    format === "toml" ? stringifyToml(updated) + "\n" : JSON.stringify(updated, null, 2) + "\n";
+  await writeFile(agent.configPath, serialized);
 }

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -17,7 +17,8 @@ export type AgentType =
   | "codex"
   | "vscode"
   | "windsurf"
-  | "amp";
+  | "amp"
+  | "factory";
 
 // path is relative to project root for project-dir, relative to homedir for user-dir;
 // binary kind probes for an executable on $PATH (cross-platform)
@@ -180,6 +181,17 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
       kind: "shell",
       bin: "amp",
       args: ["mcp", "add", "docfork", "https://mcp.docfork.com/mcp"],
+    },
+  },
+  factory: {
+    name: "factory",
+    displayName: "Factory",
+    probe: { kind: "binary", name: "droid" },
+    postWriteNote: "Run `droid` and use /mcp to complete OAuth.",
+    writer: {
+      kind: "shell",
+      bin: "droid",
+      args: ["mcp", "add", "docfork", "https://mcp.docfork.com/mcp", "--type", "http"],
     },
   },
 };

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -1,8 +1,12 @@
 import { access, readFile, writeFile, copyFile, mkdir } from "node:fs/promises";
-import { join, dirname } from "node:path";
+import { join, dirname, delimiter } from "node:path";
 import { constants } from "node:fs";
 import { homedir } from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+
+const execFileAsync = promisify(execFile);
 
 // -- Types -----------------------------------
 
@@ -12,18 +16,37 @@ export type AgentType =
   | "opencode"
   | "codex"
   | "vscode"
-  | "windsurf";
+  | "windsurf"
+  | "amp";
 
-// path is relative to project root for project-dir, relative to homedir for user-dir
+// path is relative to project root for project-dir, relative to homedir for user-dir;
+// binary kind probes for an executable on $PATH (cross-platform)
 export type ProbeSpec =
   | { kind: "project-dir"; path: string }
-  | { kind: "user-dir"; path: string };
+  | { kind: "user-dir"; path: string }
+  | { kind: "binary"; name: string };
 
 export type WriteFormat = "json" | "toml";
+
+// file: read/merge/write a config file. shell: invoke a CLI that owns the config
+export type AgentWriter =
+  | {
+      kind: "file";
+      // resolved against cwd (project-dir) or homedir (user-dir)
+      configPath: string;
+      format?: WriteFormat; // defaults to "json"
+      buildServerEntry: () => Record<string, unknown>;
+      mergeConfig: (
+        existing: Record<string, unknown>,
+        serverEntry: Record<string, unknown>
+      ) => Record<string, unknown>;
+    }
+  | { kind: "shell"; bin: string; args: string[] };
 
 export interface DetectedAgent {
   name: AgentType;
   displayName: string;
+  // for file writers: absolute config path. for shell writers: a human-readable command preview.
   configPath: string;
 }
 
@@ -31,18 +54,9 @@ export interface AgentConfig {
   name: AgentType;
   displayName: string;
   probe: ProbeSpec;
-  // resolved against cwd (project-dir) or homedir (user-dir)
-  configPath: string;
-  // defaults to "json" when omitted
-  writeFormat?: WriteFormat;
+  writer: AgentWriter;
   // optional one-line hint shown after a successful write
   postWriteNote?: string;
-  // url-only stanza; the IDE handles MCP-spec OAuth on first connect
-  buildServerEntry: () => Record<string, unknown>;
-  mergeConfig: (
-    existing: Record<string, unknown>,
-    serverEntry: Record<string, unknown>
-  ) => Record<string, unknown>;
 }
 
 // -- Registry -----------------------------------
@@ -52,118 +66,184 @@ export const AGENTS: Record<AgentType, AgentConfig> = {
     name: "cursor",
     displayName: "Cursor",
     probe: { kind: "project-dir", path: ".cursor" },
-    configPath: ".cursor/mcp.json",
-    buildServerEntry: () => ({
-      url: "https://mcp.docfork.com/mcp",
-    }),
-    mergeConfig: (existing, entry) => {
-      const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
-      mcpServers["docfork"] = entry;
-      return { ...existing, mcpServers };
+    writer: {
+      kind: "file",
+      configPath: ".cursor/mcp.json",
+      buildServerEntry: () => ({
+        url: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+        mcpServers["docfork"] = entry;
+        return { ...existing, mcpServers };
+      },
     },
   },
   "claude-code": {
     name: "claude-code",
     displayName: "Claude Code",
     probe: { kind: "project-dir", path: ".claude" },
-    configPath: ".mcp.json",
-    buildServerEntry: () => ({
-      type: "http",
-      url: "https://mcp.docfork.com/mcp",
-    }),
-    mergeConfig: (existing, entry) => {
-      const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
-      mcpServers["docfork"] = entry;
-      return { ...existing, mcpServers };
+    writer: {
+      kind: "file",
+      configPath: ".mcp.json",
+      buildServerEntry: () => ({
+        type: "http",
+        url: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+        mcpServers["docfork"] = entry;
+        return { ...existing, mcpServers };
+      },
     },
   },
   opencode: {
     name: "opencode",
     displayName: "OpenCode",
     probe: { kind: "project-dir", path: ".opencode" },
-    configPath: "opencode.json",
-    buildServerEntry: () => ({
-      type: "remote",
-      url: "https://mcp.docfork.com/mcp",
-      enabled: true,
-    }),
-    mergeConfig: (existing, entry) => {
-      const mcp = (existing.mcp ?? {}) as Record<string, unknown>;
-      mcp["docfork"] = entry;
-      return { ...existing, mcp };
+    writer: {
+      kind: "file",
+      configPath: "opencode.json",
+      buildServerEntry: () => ({
+        type: "remote",
+        url: "https://mcp.docfork.com/mcp",
+        enabled: true,
+      }),
+      mergeConfig: (existing, entry) => {
+        const mcp = (existing.mcp ?? {}) as Record<string, unknown>;
+        mcp["docfork"] = entry;
+        return { ...existing, mcp };
+      },
     },
   },
   codex: {
     name: "codex",
     displayName: "OpenAI Codex",
     probe: { kind: "user-dir", path: ".codex" },
-    configPath: ".codex/config.toml",
-    writeFormat: "toml",
     postWriteNote: "Run `codex mcp login docfork` to complete OAuth.",
-    buildServerEntry: () => ({
-      url: "https://mcp.docfork.com/mcp",
-    }),
-    mergeConfig: (existing, entry) => {
-      const mcpServers = (existing.mcp_servers ?? {}) as Record<string, unknown>;
-      mcpServers["docfork"] = entry;
-      return { ...existing, mcp_servers: mcpServers };
+    writer: {
+      kind: "file",
+      configPath: ".codex/config.toml",
+      format: "toml",
+      buildServerEntry: () => ({
+        url: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const mcpServers = (existing.mcp_servers ?? {}) as Record<string, unknown>;
+        mcpServers["docfork"] = entry;
+        return { ...existing, mcp_servers: mcpServers };
+      },
     },
   },
   vscode: {
     name: "vscode",
     displayName: "VS Code",
     probe: { kind: "project-dir", path: ".vscode" },
-    configPath: ".vscode/mcp.json",
-    buildServerEntry: () => ({
-      type: "http",
-      url: "https://mcp.docfork.com/mcp",
-    }),
-    mergeConfig: (existing, entry) => {
-      const servers = (existing.servers ?? {}) as Record<string, unknown>;
-      servers["docfork"] = entry;
-      return { ...existing, servers };
+    writer: {
+      kind: "file",
+      configPath: ".vscode/mcp.json",
+      buildServerEntry: () => ({
+        type: "http",
+        url: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const servers = (existing.servers ?? {}) as Record<string, unknown>;
+        servers["docfork"] = entry;
+        return { ...existing, servers };
+      },
     },
   },
   windsurf: {
     name: "windsurf",
     displayName: "Windsurf",
     probe: { kind: "user-dir", path: ".codeium/windsurf" },
-    configPath: ".codeium/windsurf/mcp_config.json",
-    // windsurf uses serverUrl (not url); docs say it supports OAuth for each transport type
-    buildServerEntry: () => ({
-      serverUrl: "https://mcp.docfork.com/mcp",
-    }),
-    mergeConfig: (existing, entry) => {
-      const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
-      mcpServers["docfork"] = entry;
-      return { ...existing, mcpServers };
+    writer: {
+      kind: "file",
+      configPath: ".codeium/windsurf/mcp_config.json",
+      // windsurf uses serverUrl (not url); docs say OAuth is supported per transport
+      buildServerEntry: () => ({
+        serverUrl: "https://mcp.docfork.com/mcp",
+      }),
+      mergeConfig: (existing, entry) => {
+        const mcpServers = (existing.mcpServers ?? {}) as Record<string, unknown>;
+        mcpServers["docfork"] = entry;
+        return { ...existing, mcpServers };
+      },
+    },
+  },
+  amp: {
+    name: "amp",
+    displayName: "Amp",
+    probe: { kind: "binary", name: "amp" },
+    // per docs, amp auto-starts OAuth on first connect when no headers are configured
+    writer: {
+      kind: "shell",
+      bin: "amp",
+      args: ["mcp", "add", "docfork", "https://mcp.docfork.com/mcp"],
     },
   },
 };
 
 // -- Detection -----------------------------------
 
-function probeRoot(probe: ProbeSpec, cwd: string, home: string): string {
-  return probe.kind === "project-dir" ? cwd : home;
+async function isOnPath(name: string, pathEnv: string | undefined): Promise<boolean> {
+  if (!pathEnv) return false;
+  const candidates = process.platform === "win32" ? [name, `${name}.exe`, `${name}.cmd`] : [name];
+  for (const dir of pathEnv.split(delimiter).filter(Boolean)) {
+    for (const cand of candidates) {
+      try {
+        await access(join(dir, cand), constants.X_OK);
+        return true;
+      } catch {
+        // not in this dir
+      }
+    }
+  }
+  return false;
 }
 
-export async function detectAgents(cwd?: string, home?: string): Promise<DetectedAgent[]> {
+async function probeMatches(
+  probe: ProbeSpec,
+  cwd: string,
+  home: string,
+  pathEnv: string | undefined
+): Promise<boolean> {
+  if (probe.kind === "binary") return isOnPath(probe.name, pathEnv);
+  const root = probe.kind === "project-dir" ? cwd : home;
+  try {
+    await access(join(root, probe.path), constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function detectedConfigPath(agent: AgentConfig, cwd: string, home: string): string {
+  if (agent.writer.kind === "shell") {
+    return [agent.writer.bin, ...agent.writer.args].join(" ");
+  }
+  const root = agent.probe.kind === "project-dir" ? cwd : home;
+  return join(root, agent.writer.configPath);
+}
+
+export async function detectAgents(
+  cwd?: string,
+  home?: string,
+  pathEnv?: string
+): Promise<DetectedAgent[]> {
   const dir = cwd ?? process.cwd();
   const userHome = home ?? homedir();
+  const path = pathEnv ?? process.env.PATH;
   const detected: DetectedAgent[] = [];
 
   await Promise.all(
     Object.values(AGENTS).map(async (agent) => {
-      const root = probeRoot(agent.probe, dir, userHome);
-      try {
-        await access(join(root, agent.probe.path), constants.F_OK);
+      if (await probeMatches(agent.probe, dir, userHome, path)) {
         detected.push({
           name: agent.name,
           displayName: agent.displayName,
-          configPath: join(root, agent.configPath),
+          configPath: detectedConfigPath(agent, dir, userHome),
         });
-      } catch {
-        // probe target missing
       }
     })
   );
@@ -184,10 +264,12 @@ export function agentDisplayList(): string {
 
 // -- Config writing -----------------------------------
 
-export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void> {
-  const def = AGENTS[agent.name];
-  const serverEntry = def.buildServerEntry();
-  const format = def.writeFormat ?? "json";
+async function writeFileWriter(
+  agent: DetectedAgent,
+  writer: Extract<AgentWriter, { kind: "file" }>
+): Promise<void> {
+  const serverEntry = writer.buildServerEntry();
+  const format = writer.format ?? "json";
 
   // read existing config; back it up before modifying
   let existing: Record<string, unknown> = {};
@@ -202,10 +284,20 @@ export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void
     // file doesn't exist, start fresh
   }
 
-  const updated = def.mergeConfig(existing, serverEntry);
+  const updated = writer.mergeConfig(existing, serverEntry);
 
   await mkdir(dirname(agent.configPath), { recursive: true });
   const serialized =
     format === "toml" ? stringifyToml(updated) + "\n" : JSON.stringify(updated, null, 2) + "\n";
   await writeFile(agent.configPath, serialized);
+}
+
+export async function writeMcpConfigForAgent(agent: DetectedAgent): Promise<void> {
+  const def = AGENTS[agent.name];
+  if (def.writer.kind === "file") {
+    await writeFileWriter(agent, def.writer);
+    return;
+  }
+  // shell: let the agent's CLI own its config (handles its own merge semantics)
+  await execFileAsync(def.writer.bin, def.writer.args);
 }

--- a/packages/dgrep/src/lib/agents.ts
+++ b/packages/dgrep/src/lib/agents.ts
@@ -108,6 +108,13 @@ export function getAgentDefinition(name: string): AgentConfig | undefined {
   return (AGENTS as Record<string, AgentConfig | undefined>)[name];
 }
 
+// comma-joined display names — used in "No IDE agents detected (...)" messages
+export function agentDisplayList(): string {
+  return Object.values(AGENTS)
+    .map((a) => a.displayName)
+    .join(", ");
+}
+
 // -- Config writing -----------------------------------
 
 export async function writeMcpConfigForAgent(

--- a/packages/dgrep/test/commands/wizard.test.ts
+++ b/packages/dgrep/test/commands/wizard.test.ts
@@ -4,15 +4,20 @@ import { mkdtemp, rm, mkdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
 let tempDir: string;
+let tempHome: string;
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "dgrep-wizard-test-"));
+  tempHome = await mkdtemp(join(tmpdir(), "dgrep-wizard-home-"));
+  // isolate user-dir probes (codex, etc.) from the host's real home
+  vi.stubEnv("HOME", tempHome);
 });
 
 afterEach(async () => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   await rm(tempDir, { recursive: true, force: true });
+  await rm(tempHome, { recursive: true, force: true });
 });
 
 describe("wizard command", () => {

--- a/packages/dgrep/test/commands/wizard.test.ts
+++ b/packages/dgrep/test/commands/wizard.test.ts
@@ -11,6 +11,8 @@ beforeEach(async () => {
   tempHome = await mkdtemp(join(tmpdir(), "dgrep-wizard-home-"));
   // isolate user-dir probes (codex, etc.) from the host's real home
   vi.stubEnv("HOME", tempHome);
+  // isolate binary probes (amp, etc.) from the host's $PATH
+  vi.stubEnv("PATH", "");
 });
 
 afterEach(async () => {

--- a/packages/dgrep/test/commands/wizard.test.ts
+++ b/packages/dgrep/test/commands/wizard.test.ts
@@ -1,83 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { mkdtemp, rm, mkdir, readFile } from "node:fs/promises";
-import { tmpdir, homedir } from "node:os";
-import { server } from "../setup.js";
-import { http, HttpResponse } from "msw";
-import { loadConfig, saveConfig } from "../../src/lib/config.js";
-
-const API_URL = "https://api.docfork.com/v1";
+import { tmpdir } from "node:os";
 
 let tempDir: string;
-let originalConfig: Record<string, unknown>;
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "dgrep-wizard-test-"));
-  // Save original user config to restore after test
-  originalConfig = await loadConfig();
-
-  // Add provision handler for all wizard tests
-  server.use(
-    http.post(`${API_URL}/keys/provision`, () => {
-      return HttpResponse.json({
-        api_key: "docf_test_wizard_key",
-        key_prefix: "docf_test_wizar",
-        organization_id: "org-test",
-        expires_at: "2026-04-03T00:00:00Z",
-        claim_url: "https://app.docfork.com/claim?token=test",
-      });
-    }),
-  );
 });
 
 afterEach(async () => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
-  // Restore original user config to prevent test pollution
-  await saveConfig(originalConfig as Parameters<typeof saveConfig>[0]);
   await rm(tempDir, { recursive: true, force: true });
 });
 
 describe("wizard command", () => {
-  it("provisions key and writes MCP config for detected agents (--yes)", async () => {
-    // Create .cursor/ so agent is detected
+  it("writes url-only MCP config for detected agents (--yes)", async () => {
     await mkdir(join(tempDir, ".cursor"));
-
-    // Remove existing API key env so provision is triggered
-    vi.stubEnv("DOCFORK_API_KEY", "");
 
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     const { wizard } = await import("../../src/commands/wizard.js");
     await wizard({ yes: true, cwd: tempDir });
 
-    // Should have written MCP config
     const mcpConfig = JSON.parse(await readFile(join(tempDir, ".cursor", "mcp.json"), "utf-8"));
     expect(mcpConfig.mcpServers).toHaveProperty("docfork");
     expect(mcpConfig.mcpServers.docfork.url).toBe("https://mcp.docfork.com/mcp");
-    expect(mcpConfig.mcpServers.docfork.headers.DOCFORK_API_KEY).toBeDefined();
-  });
-
-  it("uses existing API key and skips provision", async () => {
-    vi.stubEnv("DOCFORK_API_KEY", "docf_existing_from_env");
-
-    await mkdir(join(tempDir, ".cursor"));
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const { wizard } = await import("../../src/commands/wizard.js");
-    await wizard({ yes: true, cwd: tempDir });
-
-    // MCP config should use the existing key
-    const mcpConfig = JSON.parse(await readFile(join(tempDir, ".cursor", "mcp.json"), "utf-8"));
-    expect(mcpConfig.mcpServers.docfork.headers.DOCFORK_API_KEY).toBe("docf_existing_from_env");
+    expect(mcpConfig.mcpServers.docfork.headers).toBeUndefined();
   });
 
   it("handles no agents detected gracefully", async () => {
-    vi.stubEnv("DOCFORK_API_KEY", "");
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     const { wizard } = await import("../../src/commands/wizard.js");
-    // Should not throw even with no agents
     await expect(wizard({ yes: true, cwd: tempDir })).resolves.not.toThrow();
   });
 });

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -80,6 +80,32 @@ describe("detectAgents", () => {
     expect(agents.some((a) => a.name === "amp")).toBe(false);
   });
 
+  it("detects Zed when its config dir exists in home", async () => {
+    const zedDir =
+      process.platform === "darwin" ? "Library/Application Support/Zed" : ".config/zed";
+    await mkdir(join(tempHome, zedDir), { recursive: true });
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
+    expect(agents.some((a) => a.name === "zed")).toBe(true);
+    const zed = agents.find((a) => a.name === "zed");
+    expect(zed?.configPath).toBe(join(tempHome, zedDir, "settings.json"));
+  });
+
+  it("writes Zed config under context_servers", async () => {
+    const zedDir =
+      process.platform === "darwin" ? "Library/Application Support/Zed" : ".config/zed";
+    const configPath = join(tempHome, zedDir, "settings.json");
+
+    await writeMcpConfigForAgent({
+      name: "zed",
+      displayName: "Zed",
+      configPath,
+    });
+
+    const config = JSON.parse(await readFile(configPath, "utf-8"));
+    expect(config.context_servers.docfork.url).toBe("https://mcp.docfork.com/mcp");
+    expect(config.context_servers.docfork.headers).toBeUndefined();
+  });
+
   it("detects Factory when droid binary is on PATH", async () => {
     await installFakeBin("droid");
     const agents = await detectAgents(tempDir, tempHome, tempBin);
@@ -248,6 +274,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("windsurf")).toBeDefined();
     expect(getAgentDefinition("amp")).toBeDefined();
     expect(getAgentDefinition("factory")).toBeDefined();
+    expect(getAgentDefinition("zed")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -64,36 +64,38 @@ describe("detectAgents", () => {
 });
 
 describe("writeMcpConfigForAgent", () => {
-  it("writes Cursor config with url + headers under mcpServers", async () => {
+  it("writes Cursor config with url-only entry under mcpServers", async () => {
     await mkdir(join(tempDir, ".cursor"));
-    const agent = { name: "cursor", displayName: "Cursor", configPath: join(tempDir, ".cursor", "mcp.json") };
+    const agent = { name: "cursor" as const, displayName: "Cursor", configPath: join(tempDir, ".cursor", "mcp.json") };
 
-    await writeMcpConfigForAgent(agent, "docf_test123");
+    await writeMcpConfigForAgent(agent);
 
     const config = JSON.parse(await readFile(join(tempDir, ".cursor", "mcp.json"), "utf-8"));
     expect(config.mcpServers.docfork.url).toBe("https://mcp.docfork.com/mcp");
-    expect(config.mcpServers.docfork.headers.DOCFORK_API_KEY).toBe("docf_test123");
+    expect(config.mcpServers.docfork.headers).toBeUndefined();
   });
 
   it("writes Claude Code config with http type under mcpServers", async () => {
-    const agent = { name: "claude-code", displayName: "Claude Code", configPath: join(tempDir, ".mcp.json") };
+    const agent = { name: "claude-code" as const, displayName: "Claude Code", configPath: join(tempDir, ".mcp.json") };
 
-    await writeMcpConfigForAgent(agent, "docf_test123");
+    await writeMcpConfigForAgent(agent);
 
     const config = JSON.parse(await readFile(join(tempDir, ".mcp.json"), "utf-8"));
     expect(config.mcpServers.docfork.type).toBe("http");
     expect(config.mcpServers.docfork.url).toBe("https://mcp.docfork.com/mcp");
+    expect(config.mcpServers.docfork.headers).toBeUndefined();
   });
 
   it("writes OpenCode config with remote type under mcp key", async () => {
-    const agent = { name: "opencode", displayName: "OpenCode", configPath: join(tempDir, "opencode.json") };
+    const agent = { name: "opencode" as const, displayName: "OpenCode", configPath: join(tempDir, "opencode.json") };
 
-    await writeMcpConfigForAgent(agent, "docf_test123");
+    await writeMcpConfigForAgent(agent);
 
     const config = JSON.parse(await readFile(join(tempDir, "opencode.json"), "utf-8"));
     expect(config.mcp.docfork.type).toBe("remote");
     expect(config.mcp.docfork.url).toBe("https://mcp.docfork.com/mcp");
     expect(config.mcp.docfork.enabled).toBe(true);
+    expect(config.mcp.docfork.headers).toBeUndefined();
   });
 
   it("merges with existing config without overwriting", async () => {
@@ -102,8 +104,8 @@ describe("writeMcpConfigForAgent", () => {
     const { writeFile: wf } = await import("node:fs/promises");
     await wf(configPath, JSON.stringify({ mcpServers: { "other-server": { url: "http://other" } } }));
 
-    const agent = { name: "cursor", displayName: "Cursor", configPath };
-    await writeMcpConfigForAgent(agent, "docf_test123");
+    const agent = { name: "cursor" as const, displayName: "Cursor", configPath };
+    await writeMcpConfigForAgent(agent);
 
     const config = JSON.parse(await readFile(configPath, "utf-8"));
     expect(config.mcpServers["other-server"]).toBeDefined();

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -37,6 +37,14 @@ describe("detectAgents", () => {
     expect(agents.some((a) => a.name === "opencode")).toBe(true);
   });
 
+  it("detects VS Code when .vscode/ exists", async () => {
+    await mkdir(join(tempDir, ".vscode"));
+    const agents = await detectAgents(tempDir, tempHome);
+    expect(agents.some((a) => a.name === "vscode")).toBe(true);
+    const vscode = agents.find((a) => a.name === "vscode");
+    expect(vscode?.configPath).toBe(join(tempDir, ".vscode", "mcp.json"));
+  });
+
   it("detects multiple agents", async () => {
     await mkdir(join(tempDir, ".cursor"));
     await mkdir(join(tempDir, ".claude"));
@@ -110,6 +118,22 @@ describe("writeMcpConfigForAgent", () => {
     expect(config.mcp.docfork.headers).toBeUndefined();
   });
 
+  it("writes VS Code config under top-level servers key", async () => {
+    await mkdir(join(tempDir, ".vscode"));
+    const agent = {
+      name: "vscode" as const,
+      displayName: "VS Code",
+      configPath: join(tempDir, ".vscode", "mcp.json"),
+    };
+
+    await writeMcpConfigForAgent(agent);
+
+    const config = JSON.parse(await readFile(join(tempDir, ".vscode", "mcp.json"), "utf-8"));
+    expect(config.servers.docfork.type).toBe("http");
+    expect(config.servers.docfork.url).toBe("https://mcp.docfork.com/mcp");
+    expect(config.servers.docfork.headers).toBeUndefined();
+  });
+
   it("writes Codex config as TOML under [mcp_servers.docfork]", async () => {
     await mkdir(join(tempHome, ".codex"));
     const agent = {
@@ -165,6 +189,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("claude-code")).toBeDefined();
     expect(getAgentDefinition("opencode")).toBeDefined();
     expect(getAgentDefinition("codex")).toBeDefined();
+    expect(getAgentDefinition("vscode")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -1,45 +1,54 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
-import { mkdtemp, rm, mkdir, readFile } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, readFile, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { parse as parseToml } from "smol-toml";
 import { detectAgents, writeMcpConfigForAgent, getAgentDefinition } from "../../src/lib/agents.js";
 
 let tempDir: string;
 let tempHome: string;
+let tempBin: string; // fake $PATH directory for binary probes
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "dgrep-agents-test-"));
   tempHome = await mkdtemp(join(tmpdir(), "dgrep-agents-home-"));
+  tempBin = await mkdtemp(join(tmpdir(), "dgrep-agents-bin-"));
 });
 
 afterEach(async () => {
   await rm(tempDir, { recursive: true, force: true });
   await rm(tempHome, { recursive: true, force: true });
+  await rm(tempBin, { recursive: true, force: true });
 });
+
+async function installFakeBin(name: string): Promise<void> {
+  const path = join(tempBin, name);
+  await writeFile(path, "#!/bin/sh\nexit 0\n");
+  await chmod(path, 0o755);
+}
 
 describe("detectAgents", () => {
   it("detects Cursor when .cursor/ exists", async () => {
     await mkdir(join(tempDir, ".cursor"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "cursor")).toBe(true);
   });
 
   it("detects Claude Code when .claude/ exists", async () => {
     await mkdir(join(tempDir, ".claude"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "claude-code")).toBe(true);
   });
 
   it("detects OpenCode when .opencode/ exists", async () => {
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "opencode")).toBe(true);
   });
 
   it("detects VS Code when .vscode/ exists", async () => {
     await mkdir(join(tempDir, ".vscode"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "vscode")).toBe(true);
     const vscode = agents.find((a) => a.name === "vscode");
     expect(vscode?.configPath).toBe(join(tempDir, ".vscode", "mcp.json"));
@@ -49,18 +58,31 @@ describe("detectAgents", () => {
     await mkdir(join(tempDir, ".cursor"));
     await mkdir(join(tempDir, ".claude"));
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.length).toBe(3);
   });
 
   it("returns empty when no agents found", async () => {
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents).toEqual([]);
+  });
+
+  it("detects Amp when amp binary is on PATH", async () => {
+    await installFakeBin("amp");
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
+    expect(agents.some((a) => a.name === "amp")).toBe(true);
+    const amp = agents.find((a) => a.name === "amp");
+    expect(amp?.configPath).toBe("amp mcp add docfork https://mcp.docfork.com/mcp");
+  });
+
+  it("does not detect Amp when its binary is missing from PATH", async () => {
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
+    expect(agents.some((a) => a.name === "amp")).toBe(false);
   });
 
   it("detects Windsurf when ~/.codeium/windsurf/ exists in home", async () => {
     await mkdir(join(tempHome, ".codeium", "windsurf"), { recursive: true });
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "windsurf")).toBe(true);
     const ws = agents.find((a) => a.name === "windsurf");
     expect(ws?.configPath).toBe(join(tempHome, ".codeium", "windsurf", "mcp_config.json"));
@@ -68,7 +90,7 @@ describe("detectAgents", () => {
 
   it("detects Codex when ~/.codex/ exists in home", async () => {
     await mkdir(join(tempHome, ".codex"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
     expect(agents.some((a) => a.name === "codex")).toBe(true);
     const codex = agents.find((a) => a.name === "codex");
     expect(codex?.configPath).toBe(join(tempHome, ".codex", "config.toml"));
@@ -78,7 +100,7 @@ describe("detectAgents", () => {
     await mkdir(join(tempDir, ".cursor"));
     await mkdir(join(tempDir, ".claude"));
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir, tempHome);
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
 
     const cursor = agents.find((a) => a.name === "cursor");
     expect(cursor?.configPath).toBe(join(tempDir, ".cursor", "mcp.json"));
@@ -214,6 +236,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("codex")).toBeDefined();
     expect(getAgentDefinition("vscode")).toBeDefined();
     expect(getAgentDefinition("windsurf")).toBeDefined();
+    expect(getAgentDefinition("amp")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -2,34 +2,38 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "node:path";
 import { mkdtemp, rm, mkdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { parse as parseToml } from "smol-toml";
 import { detectAgents, writeMcpConfigForAgent, getAgentDefinition } from "../../src/lib/agents.js";
 
 let tempDir: string;
+let tempHome: string;
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "dgrep-agents-test-"));
+  tempHome = await mkdtemp(join(tmpdir(), "dgrep-agents-home-"));
 });
 
 afterEach(async () => {
   await rm(tempDir, { recursive: true, force: true });
+  await rm(tempHome, { recursive: true, force: true });
 });
 
 describe("detectAgents", () => {
   it("detects Cursor when .cursor/ exists", async () => {
     await mkdir(join(tempDir, ".cursor"));
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
     expect(agents.some((a) => a.name === "cursor")).toBe(true);
   });
 
   it("detects Claude Code when .claude/ exists", async () => {
     await mkdir(join(tempDir, ".claude"));
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
     expect(agents.some((a) => a.name === "claude-code")).toBe(true);
   });
 
   it("detects OpenCode when .opencode/ exists", async () => {
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
     expect(agents.some((a) => a.name === "opencode")).toBe(true);
   });
 
@@ -37,20 +41,28 @@ describe("detectAgents", () => {
     await mkdir(join(tempDir, ".cursor"));
     await mkdir(join(tempDir, ".claude"));
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
     expect(agents.length).toBe(3);
   });
 
   it("returns empty when no agents found", async () => {
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
     expect(agents).toEqual([]);
+  });
+
+  it("detects Codex when ~/.codex/ exists in home", async () => {
+    await mkdir(join(tempHome, ".codex"));
+    const agents = await detectAgents(tempDir, tempHome);
+    expect(agents.some((a) => a.name === "codex")).toBe(true);
+    const codex = agents.find((a) => a.name === "codex");
+    expect(codex?.configPath).toBe(join(tempHome, ".codex", "config.toml"));
   });
 
   it("returns correct config paths", async () => {
     await mkdir(join(tempDir, ".cursor"));
     await mkdir(join(tempDir, ".claude"));
     await mkdir(join(tempDir, ".opencode"));
-    const agents = await detectAgents(tempDir);
+    const agents = await detectAgents(tempDir, tempHome);
 
     const cursor = agents.find((a) => a.name === "cursor");
     expect(cursor?.configPath).toBe(join(tempDir, ".cursor", "mcp.json"));
@@ -98,6 +110,40 @@ describe("writeMcpConfigForAgent", () => {
     expect(config.mcp.docfork.headers).toBeUndefined();
   });
 
+  it("writes Codex config as TOML under [mcp_servers.docfork]", async () => {
+    await mkdir(join(tempHome, ".codex"));
+    const agent = {
+      name: "codex" as const,
+      displayName: "OpenAI Codex",
+      configPath: join(tempHome, ".codex", "config.toml"),
+    };
+
+    await writeMcpConfigForAgent(agent);
+
+    const raw = await readFile(join(tempHome, ".codex", "config.toml"), "utf-8");
+    const config = parseToml(raw) as { mcp_servers: { docfork: { url: string } } };
+    expect(config.mcp_servers.docfork.url).toBe("https://mcp.docfork.com/mcp");
+  });
+
+  it("preserves existing TOML tables when merging Codex config", async () => {
+    await mkdir(join(tempHome, ".codex"));
+    const configPath = join(tempHome, ".codex", "config.toml");
+    const { writeFile: wf } = await import("node:fs/promises");
+    await wf(configPath, '[mcp_servers.other]\nurl = "http://other"\n');
+
+    const agent = {
+      name: "codex" as const,
+      displayName: "OpenAI Codex",
+      configPath,
+    };
+    await writeMcpConfigForAgent(agent);
+
+    const raw = await readFile(configPath, "utf-8");
+    const config = parseToml(raw) as { mcp_servers: Record<string, { url: string }> };
+    expect(config.mcp_servers.other.url).toBe("http://other");
+    expect(config.mcp_servers.docfork.url).toBe("https://mcp.docfork.com/mcp");
+  });
+
   it("merges with existing config without overwriting", async () => {
     await mkdir(join(tempDir, ".cursor"));
     const configPath = join(tempDir, ".cursor", "mcp.json");
@@ -118,6 +164,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("cursor")).toBeDefined();
     expect(getAgentDefinition("claude-code")).toBeDefined();
     expect(getAgentDefinition("opencode")).toBeDefined();
+    expect(getAgentDefinition("codex")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -58,6 +58,14 @@ describe("detectAgents", () => {
     expect(agents).toEqual([]);
   });
 
+  it("detects Windsurf when ~/.codeium/windsurf/ exists in home", async () => {
+    await mkdir(join(tempHome, ".codeium", "windsurf"), { recursive: true });
+    const agents = await detectAgents(tempDir, tempHome);
+    expect(agents.some((a) => a.name === "windsurf")).toBe(true);
+    const ws = agents.find((a) => a.name === "windsurf");
+    expect(ws?.configPath).toBe(join(tempHome, ".codeium", "windsurf", "mcp_config.json"));
+  });
+
   it("detects Codex when ~/.codex/ exists in home", async () => {
     await mkdir(join(tempHome, ".codex"));
     const agents = await detectAgents(tempDir, tempHome);
@@ -116,6 +124,21 @@ describe("writeMcpConfigForAgent", () => {
     expect(config.mcp.docfork.url).toBe("https://mcp.docfork.com/mcp");
     expect(config.mcp.docfork.enabled).toBe(true);
     expect(config.mcp.docfork.headers).toBeUndefined();
+  });
+
+  it("writes Windsurf config under mcpServers with serverUrl", async () => {
+    await mkdir(join(tempHome, ".codeium", "windsurf"), { recursive: true });
+    const agent = {
+      name: "windsurf" as const,
+      displayName: "Windsurf",
+      configPath: join(tempHome, ".codeium", "windsurf", "mcp_config.json"),
+    };
+
+    await writeMcpConfigForAgent(agent);
+
+    const config = JSON.parse(await readFile(agent.configPath, "utf-8"));
+    expect(config.mcpServers.docfork.serverUrl).toBe("https://mcp.docfork.com/mcp");
+    expect(config.mcpServers.docfork.headers).toBeUndefined();
   });
 
   it("writes VS Code config under top-level servers key", async () => {
@@ -190,6 +213,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("opencode")).toBeDefined();
     expect(getAgentDefinition("codex")).toBeDefined();
     expect(getAgentDefinition("vscode")).toBeDefined();
+    expect(getAgentDefinition("windsurf")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/packages/dgrep/test/lib/agents.test.ts
+++ b/packages/dgrep/test/lib/agents.test.ts
@@ -80,6 +80,16 @@ describe("detectAgents", () => {
     expect(agents.some((a) => a.name === "amp")).toBe(false);
   });
 
+  it("detects Factory when droid binary is on PATH", async () => {
+    await installFakeBin("droid");
+    const agents = await detectAgents(tempDir, tempHome, tempBin);
+    expect(agents.some((a) => a.name === "factory")).toBe(true);
+    const factory = agents.find((a) => a.name === "factory");
+    expect(factory?.configPath).toBe(
+      "droid mcp add docfork https://mcp.docfork.com/mcp --type http"
+    );
+  });
+
   it("detects Windsurf when ~/.codeium/windsurf/ exists in home", async () => {
     await mkdir(join(tempHome, ".codeium", "windsurf"), { recursive: true });
     const agents = await detectAgents(tempDir, tempHome, tempBin);
@@ -237,6 +247,7 @@ describe("getAgentDefinition", () => {
     expect(getAgentDefinition("vscode")).toBeDefined();
     expect(getAgentDefinition("windsurf")).toBeDefined();
     expect(getAgentDefinition("amp")).toBeDefined();
+    expect(getAgentDefinition("factory")).toBeDefined();
   });
 
   it("returns undefined for unknown agent", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,10 @@ importers:
         version: 5.9.3
 
   packages/dgrep:
+    dependencies:
+      smol-toml:
+        specifier: ^1.6.1
+        version: 1.6.1
     devDependencies:
       '@clack/prompts':
         specifier: ^0.9
@@ -55,7 +59,7 @@ importers:
         version: 2.13.2(@types/node@25.3.3)(typescript@5.9.3)
       obuild:
         specifier: latest
-        version: 0.4.32(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1)(picomatch@4.0.3)(rollup@4.60.0)(typescript@5.9.3)
+        version: 0.4.34(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1)(typescript@5.9.3)
       picocolors:
         specifier: ^1
         version: 1.1.1
@@ -93,25 +97,25 @@ importers:
 
 packages:
 
-  '@babel/generator@8.0.0-rc.2':
-    resolution: {integrity: sha512-oCQ1IKPwkzCeJzAPb7Fv8rQ9k5+1sG8mf2uoHiMInPYvkRfrDJxbTIbH51U+jstlkghus0vAi3EBvkfvEsYNLQ==}
+  '@babel/generator@8.0.0-rc.4':
+    resolution: {integrity: sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-string-parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
+  '@babel/helper-string-parser@8.0.0-rc.4':
+    resolution: {integrity: sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.2':
-    resolution: {integrity: sha512-xExUBkuXWJjVuIbO7z6q7/BA9bgfJDEhVL0ggrggLMbg0IzCUWGT1hZGE8qUH7Il7/RD/a6cZ3AAFrrlp1LF/A==}
+  '@babel/helper-validator-identifier@8.0.0-rc.4':
+    resolution: {integrity: sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@babel/parser@8.0.0-rc.2':
-    resolution: {integrity: sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ==}
+  '@babel/parser@8.0.0-rc.4':
+    resolution: {integrity: sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  '@babel/types@8.0.0-rc.2':
-    resolution: {integrity: sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw==}
+  '@babel/types@8.0.0-rc.4':
+    resolution: {integrity: sha512-bw30DV880P/VYtsjWWdoWmJpb9S2Vn1/PqayyccTELzRQ/HslIO7+BD9rNoZ4AAFOAjC1vrNeBCkAsyh6Ibfww==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@clack/core@0.4.1':
@@ -124,14 +128,14 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/core@1.8.1':
-    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -478,8 +482,11 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -545,8 +552,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
 
   '@preact/signals-core@1.13.0':
     resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
@@ -1007,97 +1014,97 @@ packages:
       react:
         optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
-    resolution: {integrity: sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
-    resolution: {integrity: sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
-    resolution: {integrity: sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
-    resolution: {integrity: sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
-    resolution: {integrity: sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
-    resolution: {integrity: sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
-    resolution: {integrity: sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
-    resolution: {integrity: sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
-    resolution: {integrity: sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
-    resolution: {integrity: sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.11':
-    resolution: {integrity: sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==}
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
@@ -1462,10 +1469,6 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
-  array-find-index@1.0.2:
-    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
-    engines: {node: '>=0.10.0'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1598,9 +1601,6 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
-  commenting@1.1.0:
-    resolution: {integrity: sha512-YeNK4tavZwtH7jEgK1ZINXzLKm6DZdEMfsaaieOsCAN0S8vsY7UeuO3Q7d/M018EFgE+IeUAuBOKkFccBZsUZA==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1686,8 +1686,8 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1933,8 +1933,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.6:
-    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+  get-tsconfig@5.0.0-beta.5:
+    resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
+    engines: {node: '>=20.20.0'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2185,9 +2186,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2248,9 +2246,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2300,8 +2295,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  obuild@0.4.32:
-    resolution: {integrity: sha512-U6NNt0ZL6lCE6B6aU+qcBwbFU4g2DwrO/68aKhyXNUXgq0jf+fyHg9s9+ETZOLmlfJvQwub5mHF3aohGgWGYKQ==}
+  obuild@0.4.34:
+    resolution: {integrity: sha512-Sp7rv3oykKfP8ZCrJGD2untBiMnWM2jprrHo7HOetb3SudFSusHYngcCuT38wgCx/whQpWhqx+hJY6NJrLqlnA==}
     hasBin: true
 
   on-finished@2.4.1:
@@ -2329,10 +2324,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  package-name-regex@2.0.6:
-    resolution: {integrity: sha512-gFL35q7kbE/zBaPA3UKhp2vSzcPYx2ecbYuwv1ucE9Il6IIgBDweBlH8D68UFGZic2MkllKa2KHCfC1IQBQUYA==}
-    engines: {node: '>=12'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2383,6 +2374,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
     engines: {node: '>=16.20.0'}
@@ -2406,10 +2401,6 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
-
-  pretty-bytes@7.1.0:
-    resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
-    engines: {node: '>=20'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -2518,14 +2509,14 @@ packages:
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
-  rolldown-plugin-dts@0.22.5:
-    resolution: {integrity: sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw==}
-    engines: {node: '>=20.19.0'}
+  rolldown-plugin-dts@0.24.1:
+    resolution: {integrity: sha512-mh0oL67i6vJvpHsPtPutVE0CzHb2RvaEmU/JXPrTPnXx7yAUd/b9B2gCMLdW2yDylbJyPZMZIssXPkOLxMuYHA==}
+    engines: {node: ^22.18.0 || >=24.0.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
-      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
-      rolldown: ^1.0.0-rc.3
-      typescript: ^5.0.0 || ^6.0.0-beta
+      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      rolldown: ^1.0.0-rc.12
+      typescript: ^6.0.0
       vue-tsc: ~3.2.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -2537,16 +2528,10 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.11:
-    resolution: {integrity: sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==}
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
-
-  rollup-plugin-license@3.7.0:
-    resolution: {integrity: sha512-RvvOIF+GH3fBR3wffgc/vmjQn6qOn72WjppWVDp/v+CLpT0BbcRBdSkPeeIOL6U5XccdYgSIMjUyXgxlKEEFcw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
@@ -2637,33 +2622,16 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   spawn-rx@5.1.2:
     resolution: {integrity: sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==}
-
-  spdx-compare@1.0.0:
-    resolution: {integrity: sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==}
-
-  spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
-
-  spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
-
-  spdx-expression-validate@2.0.0:
-    resolution: {integrity: sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==}
-
-  spdx-license-ids@3.0.23:
-    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
-
-  spdx-ranges@2.1.1:
-    resolution: {integrity: sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==}
-
-  spdx-satisfies@5.0.1:
-    resolution: {integrity: sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2728,6 +2696,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -3042,27 +3014,27 @@ packages:
 
 snapshots:
 
-  '@babel/generator@8.0.0-rc.2':
+  '@babel/generator@8.0.0-rc.4':
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.4
+      '@babel/types': 8.0.0-rc.4
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
-  '@babel/helper-string-parser@8.0.0-rc.3': {}
+  '@babel/helper-string-parser@8.0.0-rc.4': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.2': {}
+  '@babel/helper-validator-identifier@8.0.0-rc.4': {}
 
-  '@babel/parser@8.0.0-rc.2':
+  '@babel/parser@8.0.0-rc.4':
     dependencies:
-      '@babel/types': 8.0.0-rc.2
+      '@babel/types': 8.0.0-rc.4
 
-  '@babel/types@8.0.0-rc.2':
+  '@babel/types@8.0.0-rc.4':
     dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
+      '@babel/helper-string-parser': 8.0.0-rc.4
+      '@babel/helper-validator-identifier': 8.0.0-rc.4
 
   '@clack/core@0.4.1':
     dependencies:
@@ -3079,18 +3051,18 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/core@1.8.1':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.1.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.1.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3510,10 +3482,10 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.1.1':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -3559,7 +3531,7 @@ snapshots:
   '@oven/bun-windows-x64@1.3.9':
     optional: true
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.128.0': {}
 
   '@preact/signals-core@1.13.0': {}
 
@@ -4007,54 +3979,56 @@ snapshots:
       - '@preact/signals-core'
       - preact
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.11':
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.11':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.11':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.11':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.11':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.11':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.11':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.11':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.11':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.11':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.11':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.11':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.11':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.11':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.11':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.11': {}
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
@@ -4419,13 +4393,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  array-find-index@1.0.2: {}
-
   assertion-error@2.0.1: {}
 
   ast-kit@3.0.0-beta.1:
     dependencies:
-      '@babel/parser': 8.0.0-rc.2
+      '@babel/parser': 8.0.0-rc.4
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -4473,7 +4445,7 @@ snapshots:
   c12@4.0.0-beta.4(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1):
     dependencies:
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       exsolve: 1.0.8
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -4557,8 +4529,6 @@ snapshots:
 
   commander@13.1.0: {}
 
-  commenting@1.1.0: {}
-
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -4620,7 +4590,7 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   depd@2.0.0: {}
 
@@ -4832,6 +4802,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -4903,7 +4877,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-tsconfig@4.13.6:
+  get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -5096,8 +5070,6 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
-
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5145,8 +5117,6 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
-
-  moment@2.30.1: {}
 
   ms@2.1.3: {}
 
@@ -5197,19 +5167,17 @@ snapshots:
 
   obug@2.1.1: {}
 
-  obuild@0.4.32(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1)(picomatch@4.0.3)(rollup@4.60.0)(typescript@5.9.3):
+  obuild@0.4.34(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1)(typescript@5.9.3):
     dependencies:
       c12: 4.0.0-beta.4(chokidar@5.0.0)(dotenv@17.2.4)(jiti@2.6.1)
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
-      pretty-bytes: 7.1.0
-      rolldown: 1.0.0-rc.11
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3)
-      rollup-plugin-license: 3.7.0(picomatch@4.0.3)(rollup@4.60.0)
-      tinyglobby: 0.2.15
+      rolldown: 1.0.0-rc.18
+      rolldown-plugin-dts: 0.24.1(rolldown@1.0.0-rc.18)(typescript@5.9.3)
+      tinyglobby: 0.2.16
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -5219,8 +5187,6 @@ snapshots:
       - jiti
       - magicast
       - oxc-resolver
-      - picomatch
-      - rollup
       - typescript
       - vue-tsc
 
@@ -5258,8 +5224,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  package-name-regex@2.0.6: {}
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5290,6 +5254,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pkce-challenge@4.1.0: {}
 
   pkce-challenge@5.0.1: {}
@@ -5309,8 +5275,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
-
-  pretty-bytes@7.1.0: {}
 
   prismjs@1.30.0: {}
 
@@ -5338,7 +5302,7 @@ snapshots:
 
   rc9@3.0.0:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   react-dom@18.3.1(react@18.3.1):
@@ -5406,57 +5370,42 @@ snapshots:
 
   rettime@0.10.1: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3):
+  rolldown-plugin-dts@0.24.1(rolldown@1.0.0-rc.18)(typescript@5.9.3):
     dependencies:
-      '@babel/generator': 8.0.0-rc.2
-      '@babel/helper-validator-identifier': 8.0.0-rc.2
-      '@babel/parser': 8.0.0-rc.2
-      '@babel/types': 8.0.0-rc.2
+      '@babel/generator': 8.0.0-rc.4
+      '@babel/helper-validator-identifier': 8.0.0-rc.4
+      '@babel/parser': 8.0.0-rc.4
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3
-      get-tsconfig: 4.13.6
+      get-tsconfig: 5.0.0-beta.5
       obug: 2.1.1
-      rolldown: 1.0.0-rc.11
+      rolldown: 1.0.0-rc.18
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.11:
+  rolldown@1.0.0-rc.18:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.11
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.11
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.11
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.11
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.11
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.11
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.11
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.11
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.11
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.11
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.11
-
-  rollup-plugin-license@3.7.0(picomatch@4.0.3)(rollup@4.60.0):
-    dependencies:
-      commenting: 1.1.0
-      fdir: 6.5.0(picomatch@4.0.3)
-      lodash: 4.17.23
-      magic-string: 0.30.21
-      moment: 2.30.1
-      package-name-regex: 2.0.6
-      rollup: 4.60.0
-      spdx-expression-validate: 2.0.0
-      spdx-satisfies: 5.0.1
-    transitivePeerDependencies:
-      - picomatch
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
 
   rollup@4.60.0:
     dependencies:
@@ -5603,6 +5552,8 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  smol-toml@1.6.1: {}
+
   source-map-js@1.2.1: {}
 
   spawn-rx@5.1.2:
@@ -5611,33 +5562,6 @@ snapshots:
       rxjs: 7.8.2
     transitivePeerDependencies:
       - supports-color
-
-  spdx-compare@1.0.0:
-    dependencies:
-      array-find-index: 1.0.2
-      spdx-expression-parse: 3.0.1
-      spdx-ranges: 2.1.1
-
-  spdx-exceptions@2.5.0: {}
-
-  spdx-expression-parse@3.0.1:
-    dependencies:
-      spdx-exceptions: 2.5.0
-      spdx-license-ids: 3.0.23
-
-  spdx-expression-validate@2.0.0:
-    dependencies:
-      spdx-expression-parse: 3.0.1
-
-  spdx-license-ids@3.0.23: {}
-
-  spdx-ranges@2.1.1: {}
-
-  spdx-satisfies@5.0.1:
-    dependencies:
-      spdx-compare: 1.0.0
-      spdx-expression-parse: 3.0.1
-      spdx-ranges: 2.1.1
 
   stackback@0.0.2: {}
 
@@ -5695,6 +5619,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 


### PR DESCRIPTION
## Why

dgrep's agent setup was a tangle of per-agent flags and hand-rolled probe logic, and only covered a couple of editors. This reworks it into a typed registry and adds first-class support for the editors users actually run.

## What

- **Agent registry refactor** — converted the registry to a typed `Record` + `ProbeSpec`; status/doctor now derive their agent lists from the registry instead of duplicating it; replaced per-agent flags with a single `--agent`.
- **OAuth-first setup** — `setup` flips to OAuth-first and drops key provisioning.
- **New agents** — codex (TOML), vs code, windsurf, amp (shell), factory (shell), zed.

## Test plan

- `pnpm typecheck` clean
- `pnpm test` — 145/145 pass (24 in `agents.test.ts`)
- `pnpm lint:check` clean

## Release impact

`feat(dgrep):` commits → release-please cuts `dgrep-v0.3.0` (minor, per `bump-minor-pre-major`). This advances dgrep's tag past the unscoped `Release-As: 0.0.1` commit, which unblocks removing the `last-release-sha` pin (DOC-373).
