### PR TITLE
docs(dgrep): propagate `dgrep setup --agent` syntax + retagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     </picture>
   </a>
 </p>
-<p align="center">Context for AI Coding Agents.</p>
+<p align="center">Up-to-date docs for AI coding agents.</p>
 
 <p align="center">
   <a href="https://docfork.com"><img alt="Website" src="https://img.shields.io/badge/Website-docfork.com-blue?style=flat-square" /></a>&nbsp;&nbsp;<a href="https://www.npmjs.com/package/docfork"><img alt="npm" src="https://img.shields.io/npm/v/docfork?style=flat-square&color=red" /></a>&nbsp;&nbsp;<a href="https://www.npmjs.com/package/docfork"><img alt="npm downloads" src="https://img.shields.io/npm/dm/docfork?style=flat-square" /></a>&nbsp;&nbsp;<a href="https://github.com/docfork/docfork"><img alt="GitHub stars" src="https://img.shields.io/github/stars/docfork/docfork?style=flat-square" /></a>
@@ -36,10 +36,10 @@ AI agents hallucinate APIs, bloat context with stale docs, and write code agains
 ## Get Started
 
 ```bash
-npx dgrep setup --cursor
+npx dgrep setup
 ```
 
-Installs the Docfork MCP server in your IDE. Detects your dependencies, provisions an API key, and writes the config file. Also supports `--claude` and `--opencode`.
+Installs the Docfork MCP server in your IDE. Detects your installed agents and writes the config file; sign in to Docfork on first use, no API key needed. Target one with `--agent claude-code` (also: cursor, codex, opencode, vscode, windsurf, amp, factory, zed).
 
 Your agent now has two tools:
 
@@ -90,7 +90,7 @@ Share API keys and [Cabinets](https://docfork.com/docs/cabinets) across your org
 ## MCP Setup
 
 > [!TIP]
-> Run `npx dgrep setup --cursor` (or `--claude`, `--opencode`) to install automatically. Manual config below for other clients.
+> Run `npx dgrep setup` to install automatically (use `--agent claude-code` to target one). Manual config below for other clients.
 
 **Cursor** — <a href="https://cursor.com/en/install-mcp?name=docfork&config=eyJ1cmwiOiJodHRwczovL21jcC5kb2Nmb3JrLmNvbS9tY3AifQ%3D%3D"><img src="https://cursor.com/deeplink/mcp-install-dark.svg" height="20" alt="Add to Cursor"/></a>
 

--- a/packages/dgrep/README.md
+++ b/packages/dgrep/README.md
@@ -22,7 +22,7 @@ dgrep init                                                              # detect
 dgrep search "server-side rendering with App Router"                    # search tracked libraries
 dgrep search "middleware redirect based on authentication" -l vercel/next.js  # search a specific library
 dgrep read https://nextjs.org/docs/app/building-your-application/routing/middleware
-dgrep setup                                                             # wire into Cursor, Claude Code, OpenCode
+dgrep setup                                                             # wire the MCP server into your IDE agents
 ```
 
 dgrep provisions keys automatically on first search. No API key required.
@@ -45,7 +45,7 @@ dgrep provisions keys automatically on first search. No API key required.
 | `dgrep add <library>`    | Add a library to your stack                                      |
 | `dgrep remove <library>` | Remove a library from tracking                                   |
 | `dgrep list`             | List tracked libraries                                           |
-| `dgrep setup`            | Install the Docfork MCP server in your IDE (Cursor, Claude Code, OpenCode) |
+| `dgrep setup`            | Install the Docfork MCP server in your IDE agents (use `--agent` to target one) |
 | `dgrep status`           | Show configuration and authentication state                      |
 | `dgrep login`            | Log in to your Docfork account                                   |
 | `dgrep logout`           | Log out and clear credentials                                    |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -28,10 +28,10 @@ Documentation context as precise as your dependency lockfile:
 ### Recommended: use dgrep
 
 ```bash
-npx dgrep setup --cursor
+npx dgrep setup
 ```
 
-Installs the Docfork MCP server in your IDE. Detects your dependencies, provisions an API key, and writes the config file. Also supports `--claude` and `--opencode`.
+Installs the Docfork MCP server in your IDE. Detects your installed agents and writes the config file; sign in to Docfork on first use, no API key needed. Target one with `--agent claude-code` (also: cursor, codex, opencode, vscode, windsurf, amp, factory, zed).
 
 [dgrep docs →](https://docfork.com/docs/dgrep)
 


### PR DESCRIPTION
## Why
`dgrep setup` was reworked in #166: per-agent flags (`--cursor`, `--claude`, `--opencode`) collapsed into a single repeatable `--agent <name>`, the agent set grew to nine, and key provisioning was dropped for OAuth sign-in on first use. The public READMEs still show the old flags and promise an auto-provisioned API key, so a user copy-pasting Get Started hits a removed flag. This realigns the repo + package READMEs with the shipped CLI, and updates the landing tagline to "Up-to-date docs for AI coding agents."

## What changed
- replace `npx dgrep setup --cursor` with bare `npx dgrep setup` + `--agent <name>` guidance in README, packages/mcp, packages/dgrep
- rewrite "provisions an API key" copy to OAuth-first sign-in
- retagline README header

## Context
- Triggered by #166; companion PR updates docfork/backend docs + marketing
- Non-goals: no code changes; does not touch the dgrep CLI itself (already shipped in #166)

## Impact / risk
- docs only; no behavior, env, or build changes

## Test plan
- [ ] `grep -rn "dgrep setup --cursor\|--claude\b\|--opencode\b" README.md packages` returns nothing
- [ ] README Get Started shows `npx dgrep setup`