### PR TITLE
chore: drop release-please last-release-sha pin (DOC-373)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "last-release-sha": "36ebfd9e225561197603142978fc56ef54b0c959",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "separate-pull-requests": true,


### PR DESCRIPTION
## Why
#160 pinned `last-release-sha` to the `docfork-v2.2.3` commit (`36ebfd9e`) to suppress a spurious dgrep `0.0.1` release. Root cause: the empty `Release-As: 0.0.1` commit `c8626af` (#146) carries an **unscoped** footer that release-please applies to every component, and dgrep's last tag (`dgrep-v0.2.1`) sat *before* it — so dgrep's walk window included the footer and tried to down-level it to `0.0.1`. The pin worked by globally flooring the baseline below `c8626af`, but that also resets changelog baselines for sdk + mcp and is a future-reader trap. With `dgrep-v0.2.2` now tagged (13 commits past `c8626af`), all three components — dgrep, sdk, docfork — sit after the poison commit, so it's outside every per-component walk window. The pin is no longer load-bearing and removing it restores accurate per-component baselines.

## What changed
- remove `last-release-sha` from `release-please-config.json`

## Context
- Closes DOC-373; unblocked by docfork/docfork#166 (dgrep agent registry) → #167 (`dgrep-v0.2.2`)
- History: #146 (Release-As), #157, #160 (the pin)
- Non-goals: does not alter component configs, release-type, or the `c8626af` commit itself

## Impact / risk
- affects the release pipeline only. Verified safe by reasoning: every component tag (`dgrep-v0.2.2`, `sdk-v0.0.1`, `docfork-v2.2.5`) is ahead of `c8626af`, so no walk window can re-encounter the unscoped `Release-As`.

## Test plan (post-merge)
- [ ] Release Please workflow runs clean on `main` — no spurious `dgrep 0.0.1` PR, no downgrade
- [ ] no duplicate changelog entries generated for any component
- [ ] next genuine commit to a component opens a correctly-versioned release PR